### PR TITLE
:rotating_light: fix a lot of annoying errors from pyright with types

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,7 +11,7 @@ def create_app():
 
     app = FastAPI(
         title='TDCTL-API',
-        version=0.1,
+        version="0.1",
         description='''TDCTL-database API. 
         Everything related to Tromsøstudentenes Dataforening''',
         contact={'name' : 'td', 'email' : 'td@list.uit.no'},

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Request, Response, HTTPException, Depends
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from ..db import get_database
-from ..auth_helpers import create_token, create_refresh_token, decode_token, blacklist_token, decode, is_blacklisted, authorize
+from ..auth_helpers import create_token, create_refresh_token, decode_token, blacklist_token, is_blacklisted, authorize
 from ..models import Credentials, Tokens, MemberDB, RefreshToken, RefreshTokenPayload, AccessTokenPayload, ChangePasswordPayload
 from ..utils import validate_password, passwordError
 

--- a/app/api/eventPost.py
+++ b/app/api/eventPost.py
@@ -1,7 +1,7 @@
 import datetime
 
 from fastapi import APIRouter, Response, Request, HTTPException, Depends
-from ..models import Event, EventDB, AccessTokenPayload, Member
+from ..models import AccessTokenPayload
 from ..auth_helpers import authorize
 from ..db import get_database
 from ..models import PostData, Post, CommentData

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Response, Request, HTTPException, Depends
+from fastapi import HTTPException
 from uuid import UUID
 
 def get_event_or_404(db, eid: str):

--- a/app/auth_helpers.py
+++ b/app/auth_helpers.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from pymongo import database
+from pymongo.database import Database
 from datetime import datetime, timedelta
 from jwt import encode, decode, ExpiredSignatureError, DecodeError
 from uuid import uuid4
@@ -66,7 +66,7 @@ def decode_token(token: bytes, config: Config) -> dict:
     #    raise HTTPException(401, 'Unknown error')
 
 
-def blacklist_token(refreshToken: RefreshTokenPayload, db: database):
+def blacklist_token(refreshToken: RefreshTokenPayload, db: Database):
     '''
     Blacklists the provided (decoded) refresh token.
     '''
@@ -74,7 +74,7 @@ def blacklist_token(refreshToken: RefreshTokenPayload, db: database):
     db.tokens.insert_one(refreshToken.dict())
 
 
-def is_blacklisted(refreshToken: RefreshTokenPayload, db: database):
+def is_blacklisted(refreshToken: RefreshTokenPayload, db: Database):
     '''
     Check if the provided (decoded) refresh token is blacklisted.
     '''

--- a/app/config.py
+++ b/app/config.py
@@ -20,9 +20,9 @@ class DevelopmentConfig(Config):
 
 
 class ProductionConfig(Config):
-    SECRET_KEY = os.environ.get('SECRET_KEY')
+    SECRET_KEY = os.environ.get('SECRET_KEY') or ''
     ENV = 'production'
-    MONGO_HOST = os.environ.get('DB_HOSTNAME')
+    MONGO_HOST = os.environ.get('DB_HOSTNAME') or ''
     MONGO_PORT = os.environ.get('DB_PORT')
     MONGO_DBNAME = "tdctl"
     MONGO_URI = "mongodb://%s:%s/%s" % (MONGO_HOST, MONGO_PORT, MONGO_DBNAME)

--- a/app/db.py
+++ b/app/db.py
@@ -1,9 +1,9 @@
+from pymongo.database import Database
 from app import config
-from pymongo import MongoClient, database
+from pymongo import MongoClient
 from fastapi import Request
 
-
-def get_database(request: Request) -> database:
+def get_database(request: Request) -> Database:
     return request.app.db
 
 def get_image_path(request: Request) -> str:

--- a/app/models.py
+++ b/app/models.py
@@ -1,10 +1,6 @@
 from typing import Optional, List
-from pydantic import BaseModel, SecretStr, EmailStr, UUID4, Field
-from uuid import uuid4
-from werkzeug.security import generate_password_hash
+from pydantic import BaseModel, EmailStr, UUID4
 from datetime import datetime
-from bson import ObjectId
-
 
 class AccessTokenPayload(BaseModel):
     exp: int

--- a/seeding.py
+++ b/seeding.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from uuid import UUID, uuid4
-from bson.objectid import ObjectId
 from pymongo import MongoClient
 from app import config
 import json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,6 @@
 from app import config
-from app.db import get_database, setup_db
-
-from typing import Any
-from typing import Generator
-
 import pytest
 from pymongo import MongoClient
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from seeding import seed_events, seed_members
 

--- a/tests/test_endpoints/test_auth.py
+++ b/tests/test_endpoints/test_auth.py
@@ -1,4 +1,3 @@
-from app.db import get_test_db
 from tests.conftest import client_login
 from .test_members import regular_member
 from app.auth_helpers import decode_token

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -83,7 +83,7 @@ def test_update_event(client):
     assert response.status_code == 200
 
     event = db.events.find_one({'eid': eid})
-    assert event["title"] == update_field["title"]
+    assert event and event["title"] == update_field["title"]
 
 def test_get_all_event(client):
     response = client.get("/api/event/")

--- a/tests/test_endpoints/test_members.py
+++ b/tests/test_endpoints/test_members.py
@@ -64,6 +64,7 @@ def test_get_members(client):
 
 def test_get_member_by_id(client):
     member = db.members.find_one({'email': regular_member["email"]})
+    assert member
     access_token = client_login(client, regular_member['email'], regular_member['password'])
     headers = {"Authorization": f"Bearer {access_token}"}
     response = client.get("/api/member/", headers=headers, data=member["id"])
@@ -80,7 +81,7 @@ def test_update_member(client):
     response = client.put("/api/member/", headers=headers, json=update_value)
     assert response.status_code == 201
     member = db.members.find_one({'email': regular_member["email"]})
-    assert update_value["classof"] == member["classof"]
+    assert member and update_value["classof"] == member["classof"]
 
 def test_member_activation(client):
     response = client.post("/api/member/activate")
@@ -90,4 +91,4 @@ def test_member_activation(client):
     response = client.post("/api/member/activate", headers=headers)
     assert response.status_code == 200
     member = db.members.find_one({'email': regular_member["email"]})
-    assert member["status"] == "active"
+    assert member and member["status"] == "active"

--- a/tests/test_validation/test_password_validation.py
+++ b/tests/test_validation/test_password_validation.py
@@ -1,4 +1,3 @@
-import pytest
 from app.utils.validation import validate_password
 
 def test_validate_password():


### PR DESCRIPTION
There was a bunch of annoying errors from pyright so I wanted to remove the worst ones that were easy fixes.

- Removed a lot of unused imports
- Fix return type of `get_database`
- Assert that variable is not None some places where it could be

Note there are still some warnings/errors that I didn't fix. Especially regarding `decode_token` where it specifies that it want `bytes` as an argument, but we are passing in `str` a lot of places. I can look at converting the strings to bytes before passing in to remove the warning/error from pyright.

There are also some places in configuring FastAPI, but I didn't find an easy fix for this yet.