### PR TITLE
Feature/docker compose

### DIFF
--- a/.docker/docker-compose.development.yml
+++ b/.docker/docker-compose.development.yml
@@ -2,13 +2,37 @@ version: "3.5"
 services:
   tdctl_api:
     image: tdctl_api:latest
+    restart: always
+    container_name: tdctl_api
+    build: ../
+    volumes:
+        - ../:/app
     build:
       context: ../
       dockerfile: .docker/dockerfile.api.development
-    ports:
-      - "11000:5000"
-  mongodb:
-    image: mongo:latest
-    restart: always
     environment:
-      MONGO_INITDB_DATABASE: tdctl
+      DB_HOSTNAME: td_mongodb
+      DB_PORT: 26900
+    links:
+      - mongodb
+    depends_on:
+      - mongodb
+    ports:
+      - "5000:5000"
+    networks:
+      - backend
+
+  mongodb:
+    hostname: td_mongodb
+    image: mongo:latest
+    command: mongod --port 26900
+    restart: always
+    volumes:
+      - ../db/db_data:/data/db
+    networks:
+      - backend
+
+networks:
+  backend:
+    external: false
+    driver: bridge

--- a/.docker/dockerfile.api.development
+++ b/.docker/dockerfile.api.development
@@ -3,7 +3,7 @@ FROM python:3 as Build
 WORKDIR /app
 COPY . .
 RUN pip3 install pipenv
-RUN pipenv lock --requirements > requirements.txt
+RUN pipenv requirements > requirements.txt
 
 RUN pip3 install -r requirements.txt
 CMD ["python3", "manage.py"]

--- a/.docker/dockerfile.api.development
+++ b/.docker/dockerfile.api.development
@@ -1,4 +1,4 @@
-FROM python:3 as Build
+FROM python:3.8.9
 
 WORKDIR /app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -7,10 +7,20 @@
 ### 1. Clone this repository by running:
   * ```git clone https://github.com/td-org-uit-no/tdctl-api.git```
 
-### 2. Launching locally
+### 2. Developing
+You can either start up both the backend and mongodb locally, or you can run them in separate docker containers using docker-compose.
+
+**NB: Doing both may result in issues since docker and mongod will in some cases use different users for writing to the volume folder `db_data`. If this happen, you should either try to fix the permissions of the folder, or you can delete and recreate it**
+
+#### 2.1 Locally
   * To run the API locally use the `manage.py` script, which will run a local instance of the API:  ```./manage.py``` 
+  * To run mongodb locally you must be inside the db folder, and then run `mongod -f db.yml`. `db.yml` uses relative paths, and the relative paths are relative from where you run the command from and not from the file itself.
   * The HTTP server should by default be run on [localhost:5000](http://localhost:5000/)
   * Please note that datasources(or equivalent mockup code) used by the API must be available for all functionality to work.
+
+#### 2.2 Docker
+  * To use docker, you can run `docker-compose -f .docker/docker-compose.development.yml`. This will launch both the backend and mongodb inside two separate containers.
+  * To see output from the backend while working, you can use `docker logs tdctl_api -f`.
 
 ## Tests :heavy_check_mark:
 The test are running on a test client who resets after every test. To create data available over multiple tests insert the seeding in the client instance in `conftest.py`

--- a/app/config.py
+++ b/app/config.py
@@ -13,8 +13,8 @@ class Config:
 class DevelopmentConfig(Config):
     SECRET_KEY = "crashtest"
     ENV = 'development'
-    MONGO_HOST = "127.0.0.1"
-    MONGO_PORT = 27018
+    MONGO_HOST = os.environ.get('DB_HOSTNAME') or "127.0.0.1"
+    MONGO_PORT = int(os.environ.get('DB_PORT') or 27018)
     MONGO_DBNAME = "tdctl"
     MONGO_URI = "mongodb://%s:%s/%s" % (MONGO_HOST, MONGO_PORT, MONGO_DBNAME)
 


### PR DESCRIPTION
I have wanted to add `docker-compose` for running mongodb in for a while, but didn't bother since I didn't have any issues with running it locally (until now). 

I suddenly had some errors related to running `mongod`, and I therefore thought I could set up `docker-compose` for running mongodb.

EDIT: I realised there was already a docker-compose for dev, so I modified that to work correctly with starting both the backend and mongodb and allowing them to talk to eachother