### PR TITLE
Feature/create admin and delete member

### DIFF
--- a/app/auth_helpers.py
+++ b/app/auth_helpers.py
@@ -10,6 +10,12 @@ from .models import MemberDB, RefreshTokenPayload, AccessTokenPayload
 
 security_scheme = HTTPBearer()
 
+def authorize_admin(request: Request, token: HTTPAuthorizationCredentials = Depends(security_scheme)):
+    payload = authorize(request, token)
+    
+    if payload.role != "admin":
+        raise HTTPException(403, 'Insufficient privileges to access this resource')
+    return payload
 
 def authorize(request: Request, token: HTTPAuthorizationCredentials = Depends(security_scheme)):
     '''

--- a/tests/test_endpoints/test_admin.py
+++ b/tests/test_endpoints/test_admin.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 from app.db import get_test_db
+from app.models import MemberInput
 from tests.conftest import client_login
 
 payload = {
@@ -15,8 +16,14 @@ regular_member = {
     "password": "Test!234"
 }
 
+second_member = {
+    "email": "first@lastname.com",
+    "password": "Test!234"
+}
+
 second_admin = {
     "email": "second_admin@test.com",
+    "password": "&AdminTester1"
 }
 
 admin_member = {
@@ -31,6 +38,38 @@ def generate_non_existing_uuid():
     while db.members.find_one({'id': id}):
         id = uuid4().hex
     return id
+
+def test_create_admin(client):
+    # check if endpoint requires authentication
+    response = client.post("/api/admin/")
+    assert response.status_code == 403
+
+    # test admin authentication
+    access_token = client_login(client, regular_member["email"], regular_member["password"])
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = client.post("/api/admin/", json=payload, headers=headers)
+    assert response.status_code == 403
+
+    access_token = client_login(client, admin_member["email"], admin_member["password"])
+    headers = {"Authorization": f"Bearer {access_token}"}
+    # tests password requirements
+    unvalid_pwd = {**payload, "password": "unvalid_pwd"}
+    response = client.post("/api/admin/", json=unvalid_pwd, headers=headers)
+    assert response.status_code == 400
+
+    existing_member = db.members.find_one({'email': second_member["email"]})
+    assert existing_member
+    
+    # testing creating a user with existing email
+    existing_member = MemberInput.parse_obj(existing_member).dict()
+    response = client.post("/api/admin/", json=existing_member, headers=headers)
+    assert response.status_code == 409
+
+    #testing excepted behavior
+    response = client.post("/api/admin/", json=payload, headers=headers)
+    assert response.status_code == 201
+    new_admin = db.members.find_one({'email': payload["email"]})
+    assert new_admin and new_admin["role"] == "admin"
 
 def test_admin_update_member(client):
     update_value = {"classof": "2016"}
@@ -68,3 +107,67 @@ def test_admin_update_member(client):
 
     admin = db.members.find_one({'email': second_admin["email"]})
     assert admin and update_value["classof"] != admin["classof"]
+
+def test_delete_user(client):
+    member = db.members.find_one({'email': regular_member["email"]})
+    assert member
+    
+    # checks that the endpoint requires authentication
+    response = client.delete(f"api/admin/member/{member['id']}")
+    assert response.status_code == 403
+
+    # checks if the endpoint is admin protected
+    access_token = client_login(client, regular_member["email"], regular_member["password"])
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = client.delete(f"/api/admin/member/{member['id']}", headers=headers)
+    assert response.status_code == 403
+    
+    # checks if endpoint is protected against deleting non existing user
+    non_existing_id = generate_non_existing_uuid()
+    access_token = client_login(client, admin_member["email"], admin_member["password"])
+    headers = {"Authorization": f"Bearer {access_token}"}
+    response = client.delete(f"/api/admin/member/{non_existing_id}", headers=headers)
+    assert response.status_code == 404
+
+    admin = db.members.find_one({'email': second_admin["email"]})
+    assert admin
+    
+    # checks if cannot delete another admin
+    response = client.delete(f"/api/admin/member/{admin['id']}", headers=headers)
+    assert response.status_code == 403
+
+    # checks expected behavior
+    response = client.delete(f"/api/admin/member/{member['id']}", headers=headers)
+    assert response.status_code == 200
+    assert db.members.find_one('id', member["id"]) == None
+
+def test_give_admin_privileges(client):
+    member = db.members.find_one({'email': regular_member["email"]})
+    assert member
+    
+    # checks that the endpoint requires authentication
+    response = client.post(f"api/admin/give-admin-privileges/{member['id']}")
+    assert response.status_code == 403
+
+    # check if the endpoint is admin protected
+    access_token = client_login(client, second_member["email"], second_member["password"])
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    response = client.post(f"api/admin/give-admin-privileges/{member['id']}", headers=headers, data="")
+    assert response.status_code == 403
+
+    admin = db.members.find_one({'email': admin_member["email"]})
+    assert admin
+
+    # check response for admin upgrading admin
+    access_token = client_login(client, admin_member["email"], admin_member["password"])
+    headers = {"Authorization": f"Bearer {access_token}"}
+    
+    response = client.post(f"api/admin/give-admin-privileges/{admin['id']}", headers=headers)
+    assert response.status_code == 400
+
+    # checks if the endpoint working as expected
+    response = client.post(f"api/admin/give-admin-privileges/{member['id']}", headers=headers, data="")
+    assert response.status_code == 201
+    member = db.members.find_one({'email': member["email"]})
+    assert member and member["role"] == "admin"


### PR DESCRIPTION
# :sparkles:  Adding three endpoints for admin users :sparkles: 
 - ### :passport_control:  All endpoints requires admin privileges
 - ### :police_officer: Admins cannot change other admins
- ## POST - `api/admin` :mailbox_with_mail: 
  - Endpoint for creating new admin users
- ## POST - `api/admin/give-admin-privileges/{member_id}`  :mailbox_with_mail: 
  - Endpoint for giving a specific user admin privileges 
  - May become useful
- ##  DELETE `api/admin/member/{member_id}` :wastebasket: 
  - Deletes a specific member