### PR TITLE
Feature/test auth decorators

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -9,15 +9,14 @@ from uuid import uuid4, UUID
 
 from app.utils.validation import validate_image_file_type, validate_uuid
 from ..db import get_database, get_image_path
-from ..auth_helpers import authorize, role_required
+from ..auth_helpers import authorize, authorize_admin, role_required
 from ..models import Event, EventDB, AccessTokenPayload, EventInput, EventUpdate
 from .utils import get_event_or_404
 
 router = APIRouter()
 
 @router.post('/')
-def create_event(request: Request, newEvent: EventInput, token: AccessTokenPayload = Depends(authorize)):
-    role_required(token, "admin")
+def create_event(request: Request, newEvent: EventInput, token: AccessTokenPayload = Depends(authorize_admin)):
     db = get_database(request)
 
     # TODO better format handling and date date-time handling
@@ -75,8 +74,7 @@ def get_event_picture(request: Request, id:str):
     return FileResponse(file_name)
 
 @router.post('/{id}/image', dependencies=[Depends(validate_uuid)])
-def upload_event_picture(request: Request, id:str, image: UploadFile = File(...), token: AccessTokenPayload = Depends(authorize)):
-    role_required(token, "admin")
+def upload_event_picture(request: Request, id:str, image: UploadFile = File(...), token: AccessTokenPayload = Depends(authorize_admin)):
     if not validate_image_file_type(image.content_type):
         raise HTTPException(400, "Unsupported file type")
 
@@ -94,8 +92,7 @@ def upload_event_picture(request: Request, id:str, image: UploadFile = File(...)
     return Response(status_code=200)
 
 @router.put('/{id}', dependencies=[Depends(validate_uuid)])
-def update_event(request: Request, id:str, eventUpdate: EventUpdate, AccessTokenPayload = Depends(authorize)):
-    role_required(AccessTokenPayload, "admin")
+def update_event(request: Request, id:str, eventUpdate: EventUpdate, AccessTokenPayload = Depends(authorize_admin)):
     db = get_database(request)
 
     values = eventUpdate.dict(exclude_none=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import warnings
 import os
 from app import config
 from pymongo import MongoClient
@@ -22,8 +21,6 @@ def app():
 # The db resets after every test
 @pytest.fixture
 def client(app):
-    # removes warnings in docker env
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
     mongo_client = MongoClient(app.config.MONGO_URI)
     # change the fastapi db to the test database
     app.db = mongo_client[app.config.MONGO_DBNAME]

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --ignore=/utils
+filterwarnings =
+    ignore::DeprecationWarning

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,38 @@
+from uuid import uuid4
+import pytest
+from tests.utils.authentication import perform_request, validate_admin, validate_authentication
+
+# testes decorator function which throws exceptions when params are wrong in a decorator
+def test_decorator_request_error_handling(client):
+    valid_path = f"api/admin/give-admin-privileges/{uuid4().hex}"
+    invalid_method = "yikes"
+    # check for invalid method
+    with pytest.raises(Exception):
+        perform_request(client, valid_path, invalid_method)
+    # check for 405, unsupported method
+    with pytest.raises(Exception):
+        perform_request(client, valid_path, "delete")
+    # has to be in separate with or the test will pass when only one is throwing an exception 
+    with pytest.raises(Exception):
+        perform_request(client, "test", "post")
+    # check for 307 exception
+    with pytest.raises(Exception):
+        perform_request(client, "api/admin", "post")
+
+def test_admin_decorator(client):
+    no_auth_path = "api/event/upcoming"
+    auth_path = "api/member/"
+    admin_path = "api/admin/"
+    valid_method = "get"
+
+    assert validate_admin(client, no_auth_path, valid_method) == False
+    assert validate_admin(client, auth_path, valid_method) == False
+    assert validate_admin(client, admin_path, "post") == True
+
+def test_auth_decorator(client):
+    no_auth_path = "api/event/upcoming"
+    auth_path = "api/member/"
+    valid_method = "get"
+
+    assert validate_authentication(client, no_auth_path, valid_method) == False
+    assert validate_authentication(client, auth_path, valid_method) == True

--- a/tests/test_endpoints/test_auth.py
+++ b/tests/test_endpoints/test_auth.py
@@ -1,7 +1,8 @@
 from tests.conftest import client_login
-from .test_members import regular_member
+from tests.utils.authentication import authentication_required
 from app.auth_helpers import decode_token
 from app.config import config
+from tests.users import regular_member
 
 def test_login(client):
     unregister_user = {
@@ -25,9 +26,8 @@ def test_refresh_token(client):
     token_payload = decode_token(res_json["accessToken"], config["test"])
     assert token_payload["access_token"] == True
 
+@authentication_required('/api/auth/password', "post")
 def test_change_password(client):
-    response = client.post("/api/auth/password")
-    assert response.status_code == 403
     change_password_payload = {
         "password": regular_member["password"],
         "newPassword": "NewPassword!2"

--- a/tests/test_endpoints/test_mail.py
+++ b/tests/test_endpoints/test_mail.py
@@ -1,0 +1,5 @@
+from tests.utils.authentication import admin_required
+
+@admin_required("api/mail/send-mail/", "post")
+def test_mail_admin_required(client):
+    pass

--- a/tests/users.py
+++ b/tests/users.py
@@ -1,0 +1,20 @@
+regular_member = {
+    "email": "test@test.com",
+    "password": "Test!234"
+}
+
+second_member = {
+    "email": "first@lastname.com",
+    "password": "Test!234"
+}
+
+second_admin = {
+    "email": "second_admin@test.com",
+    "password": "&AdminTester1"
+}
+
+admin_member = {
+    "email": "test_admin@test.com",
+    "password": "&AdminTester1"
+}
+

--- a/tests/utils/authentication.py
+++ b/tests/utils/authentication.py
@@ -1,0 +1,96 @@
+import re
+import random
+import pytest
+from uuid import uuid4
+from tests.conftest import client_login
+from tests.users import regular_member
+
+# Both decorators follows the URI structure as FastApi meaning {} indicates that a value should be inserted
+# only difference is that the data type has to be defined inside the curly brackets e.g "some_path/{int}/" -> some_path/69
+
+def get_request_method(client, method):
+    method = method.lower()
+    client_func = {
+        "get": client.get,
+        "post": client.post,
+        "put": client.put,
+        "delete": client.delete,
+    }
+
+    try:
+        return client_func[method]
+    except KeyError:
+        raise Exception(f"{method} is not a valid method")
+
+def get_type(key):
+    # random values to insert when detecting {} in path
+    supported_types = {
+        "uuid": uuid4().hex,
+        "int": random.randint(0, 100)
+    }
+    try:
+        return supported_types[key.lower()]
+    except KeyError:
+        raise Exception(f"ERROR(Got unsupported type in path): got {key}")
+
+# parse path and checks for {type} which indicates that a path needs an arbitrary value inserted instead of {type}
+def parse_path(path):
+    regexp = r'\{(.*?)\}'
+    res = re.findall(regexp, path)
+    for r in res:
+        val = get_type(r)
+        path = re.sub(regexp, f'{val}', path, count=1)
+    return path
+
+def perform_request(client, path, method, header=None):
+    client_func = get_request_method(client, method)
+    path = parse_path(path)
+    response = client_func(path, headers=header)
+
+    if response.status_code == 307:
+        raise Exception(f"got Temporary redirect on :{path}, possible missing trailing slash ")
+
+    response_json = response.json()
+    if response.status_code == 405:
+        raise Exception(f"{method.upper()} is a invalid method for {path}")
+
+    # improvement detail directly from FASTAPI
+    if response.status_code == 404 and response_json['detail'] == 'Not Found':
+        raise Exception(f"{path} is not an existing endpoint")
+
+    return response
+
+def validate_authentication(client, path, method) -> bool:
+    response = perform_request(client, path, method)
+
+    return bool(response.status_code == 403)
+
+def validate_admin(client, path, method) -> bool:
+    access_token = client_login(client, regular_member["email"], regular_member["password"])
+    header = {"Authorization": f"Bearer {access_token}"}
+    response = perform_request(client, path, method, header)
+
+    return bool(response.status_code == 403)
+
+# decorator for testing if an endpoint is correctly enforcing authentication correctly
+# pass function to decorator to work with pytes client
+def authentication_required(path, method):
+    def decorator(func):
+        def wrapper(client):
+            if not validate_authentication(client, path, method):
+                raise Exception("Authentication is not enforced for protected endpoint")
+            return func(client)
+        return wrapper
+    return decorator
+
+# decorator for testing if an endpoint is correctly enforcing admin authentication
+def admin_required(path, method):
+    def decorator(func):
+        def wrapper(client):
+            if not validate_authentication(client, path, method):
+                raise Exception("No authentication for admin resource")
+            if not validate_admin(client, path, method):
+                raise Exception("Regular user can acess admin resource")
+            return func(client)
+        return wrapper
+    return decorator


### PR DESCRIPTION
## :warning: Depending on [fix/run test in docker](https://github.com/td-org-uit-no/tdctl-api/pull/39) :warning: 
## :passport_control: Adding decorators for testing endpoint authorazation:
**The decorators requires two arguments path(which endpoint), and method(method to perform)**
  - The decorator uses same logic as the Fastapi router path except that the decorator expects a type instead of a value. 
  Example: `api/member/get_member_by_id/{id}` will be `api/member/get_member_by_id/{uuid}` for the decorator 
  - ### `@admin_required` checks that a endpoint only allows admin users to access
  - ### `@authorazation_required` checks that login require is enforced