### PR TITLE
:bug: fix build context for nginx

### DIFF
--- a/.docker/docker-compose.production.yml
+++ b/.docker/docker-compose.production.yml
@@ -31,8 +31,8 @@ services:
       - backend
   nginx:
     build:
-      context: ./
-      dockerfile: dockerfile.nginx
+      context: ../
+      dockerfile: .docker/dockerfile.nginx
     image: nginx:latest
     ports:
       - "80:80"


### PR DESCRIPTION
## :bug: The docker compose for porduction was using the wrong build context 
  - set build context to `..` to be able to copy .config  