### PR TITLE
Fix/mongodb UUID object storage

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -2,8 +2,7 @@ from fastapi import HTTPException
 from uuid import UUID
 
 def get_event_or_404(db, eid: str):
-    eid = UUID(eid).hex
-    event = db.events.find_one({'eid': eid})
+    event = db.events.find_one({'eid': UUID(eid)})
 
     if not event:
         raise HTTPException(404, "Event could not be found")

--- a/app/db.py
+++ b/app/db.py
@@ -17,7 +17,7 @@ def get_export_path(request: Request) -> str:
 
 
 def setup_db(app):
-    app.db = MongoClient(app.config.MONGO_URI)[app.config.MONGO_DBNAME]
+    app.db = MongoClient(app.config.MONGO_URI, uuidRepresentation="standard")[app.config.MONGO_DBNAME]
     app.export_path = 'db/eventExports/'
     if app.config.MONGO_DBNAME == 'test':
         app.image_path = 'db/testEventImages'
@@ -27,4 +27,4 @@ def setup_db(app):
 
 def get_test_db():
     test_config = config['test']
-    return MongoClient(test_config.MONGO_URI)[test_config.MONGO_DBNAME]
+    return MongoClient(test_config.MONGO_URI, uuidRepresentation="standard")[test_config.MONGO_DBNAME]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def app():
 # The db resets after every test
 @pytest.fixture
 def client(app):
-    mongo_client = MongoClient(app.config.MONGO_URI)
+    mongo_client = MongoClient(app.config.MONGO_URI, uuidRepresentation="standard")
     # change the fastapi db to the test database
     app.db = mongo_client[app.config.MONGO_DBNAME]
     # safty check asserting we only clear our test database

--- a/tests/test_endpoints/test_admin.py
+++ b/tests/test_endpoints/test_admin.py
@@ -47,8 +47,6 @@ def test_create_admin(client):
 @admin_required("/api/admin/member/{uuid}", "PUT")
 def test_admin_update_member(client):
     update_value = {"classof": "2016"}
-    member = db.members.find_one({'email': regular_member["email"]})
-    assert member
 
     member = db.members.find_one({'email': regular_member["email"]})
     assert member and update_value["classof"] != member["classof"]
@@ -57,7 +55,7 @@ def test_admin_update_member(client):
     access_token = client_login(client, admin_member["email"], admin_member["password"])
     headers = {"Authorization": f"Bearer {access_token}"}
 
-    response = client.put(f"/api/admin/member/{member['id']}", headers=headers, json=update_value)
+    response = client.put(f"/api/admin/member/{member['id'].hex}", headers=headers, json=update_value)
     assert response.status_code == 201
 
     member = db.members.find_one({'email': regular_member["email"]})
@@ -72,7 +70,7 @@ def test_admin_update_member(client):
     admin = db.members.find_one({'email': second_admin["email"]})
     assert admin
 
-    response = client.put(f"/api/admin/member/{admin['id']}", headers=headers, json=update_value)
+    response = client.put(f"/api/admin/member/{admin['id'].hex}", headers=headers, json=update_value)
     assert response.status_code == 403
 
     admin = db.members.find_one({'email': second_admin["email"]})
@@ -100,7 +98,7 @@ def test_delete_user(client):
     # checks expected behavior
     response = client.delete(f"/api/admin/member/{member['id']}", headers=headers)
     assert response.status_code == 200
-    assert db.members.find_one('id', member["id"]) == None
+    assert db.members.find_one({'id': member["id"]}) == None
 
 @admin_required("api/admin/give-admin-privileges/{uuid}", "post")
 def test_give_admin_privileges(client):

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -64,7 +64,7 @@ def test_create_event(client):
     response = client.post("/api/event/", json=new_event, headers=headers)
     assert response.status_code == 200
     res_json = response.json()
-    event = db.events.find_one({'eid': res_json["eid"]})
+    event = db.events.find_one({'eid': UUID(res_json["eid"])})
     assert event != None
 
 
@@ -90,7 +90,7 @@ def test_update_event(client):
         f"/api/event/{eid}", json=update_field, headers=headers)
     assert response.status_code == 200
 
-    event = db.events.find_one({'eid': eid})
+    event = db.events.find_one({'eid': UUID(eid)})
     assert event and event["title"] == update_field["title"]
 
 
@@ -168,7 +168,7 @@ def test_get_event_participants(client):
         f'/api/event/{non_existing_eid}/participants', headers=headers)
     assert response.status_code == 404
 
- # Check !admin
+    # Check !admin
     response = client.get(f'/api/event/{eid}/participants', headers=headers)
     res_json = response.json()
     assert response.status_code == 200

--- a/tests/test_endpoints/test_members.py
+++ b/tests/test_endpoints/test_members.py
@@ -82,7 +82,7 @@ def test_get_member_by_email(client):
     response = client.get(f"/api/member/email/{member['email']}", headers=headers)
     assert response.status_code == 200
     res = response.json()
-    assert res["id"] == member["id"]
+    assert res["id"] == member["id"].hex
 
 @authentication_required('api/member/', 'put')
 def test_update_member(client):


### PR DESCRIPTION
## :zap: Move from storing UUID as native MongoDB objects instead of string representation
  - ### :wrench: Set mongoClient UUID representation to `standard` 
### Minor changes:
  - Only send mail in `production` environment 