### PR TITLE
:construction_worker: Run backend tests in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,33 @@
+name: Backend tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  TEST_DB_HOSTNAME: localhost
+  TEST_DB_PORT: 27017
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.8.0
+
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Run tests
+        run: |
+          pipenv install
+          pipenv run pytest

--- a/app/config.py
+++ b/app/config.py
@@ -17,7 +17,7 @@ class DevelopmentConfig(Config):
     MONGO_PORT = int(os.environ.get('DB_PORT') or 27018)
     MONGO_DBNAME = "tdctl"
     MONGO_URI = "mongodb://%s:%s/%s" % (MONGO_HOST, MONGO_PORT, MONGO_DBNAME)
-    FRONTEND_URL = os.environ.get('FRONTEND_URL')
+    FRONTEND_URL = os.environ.get('FRONTEND_URL') or "localhost:3000"
 
 
 class ProductionConfig(Config):
@@ -27,17 +27,17 @@ class ProductionConfig(Config):
     MONGO_PORT = int(os.environ.get('DB_PORT') or 27017)
     MONGO_DBNAME = "tdctl"
     MONGO_URI = "mongodb://%s:%s/%s" % (MONGO_HOST, MONGO_PORT, MONGO_DBNAME)
-    FRONTEND_URL = os.environ.get('FRONTEND_URL')
+    FRONTEND_URL = os.environ.get('FRONTEND_URL') or "localhost:3000"
 
 
 class TestConfig(Config):
     SECRET_KEY = "test"
     ENV = 'test'
     MONGO_HOST = os.environ.get('TEST_DB_HOSTNAME') or '127.0.0.1'
-    MONGO_PORT = 27018
+    MONGO_PORT = int(os.environ.get('TEST_DB_PORT') or 27018)
     MONGO_DBNAME = "test"
     MONGO_URI = "mongodb://%s:%s/%s" % (MONGO_HOST, MONGO_PORT, MONGO_DBNAME)
-    FRONTEND_URL = os.environ.get('FRONTEND_URL')
+    FRONTEND_URL = os.environ.get('FRONTEND_URL') or "localhost:3000"
 
 
 config = {

--- a/db/seeds/test_seeds/test_events.json
+++ b/db/seeds/test_seeds/test_events.json
@@ -1,6 +1,6 @@
 [
   {
-    "eid": "b6714a37-d23f-4263-a130-301551a66034",
+    "eid": "b6714a37d23f4263a130301551a66034",
     "title": "Test arrangement",
     "address": "Realfagbygget A036",
     "date": "2021-05-24 16:30:00",
@@ -15,7 +15,7 @@
     "active": true
   },
   {
-    "eid": "b6714a37-d23f-4263-a130-301551a66033",
+    "eid": "b6714a37d23f4263a130301551a66033",
     "title": "Old event",
     "address": "Realfagbygget A036",
     "date": "2020-01-01 18:00:00",


### PR DESCRIPTION
Since we are not far away from a release👀 I thought we should have the tests as part of the CI

# Changes :gem:
- Adds a workflow to run the tests on a PR

## Other small changes
- Add default `FRONTEND_URL` to `localhost:3000`.
- Configurable mongodb port for testing

# Other things:

- I could try to add some caching to avoid it having to download the same things on every action, but that can also be done in the future as it's still really fast without caching

Fixes #32