### PR TITLE
Feature/job announcement update

### DIFF
--- a/app/api/events.py
+++ b/app/api/events.py
@@ -219,14 +219,13 @@ def join_event(request: Request, id: str, payload: JoinEventPayload, token: Acce
     new_fields = {**member, **participantData}
     participant = Participant.parse_obj(new_fields)
 
-    db.events.update_one({'eid': event['eid']}, {
+    res = db.events.update_one({'eid': event['eid']}, {
         "$addToSet": {"participants": participant.dict()}})
 
-    if event['maxParticipants']:
-        if len(event['participants']) >= event['maxParticipants']:
-            return {'max': True}
+    if res == None:
+        raise HTTPException(500, "Unexpected error updating database in join")
 
-    return {'max': False}
+    return Response(status_code=200)
 
 
 @router.post('/{id}/leave', dependencies=[Depends(validate_uuid)])
@@ -260,14 +259,13 @@ def leave_event(request: Request, id: str, token: AccessTokenPayload = Depends(a
                 {"$inc": {'penalty': 1}}
             )
 
-    db.events.update_one({'eid': event['eid']}, {
+    res = db.events.update_one({'eid': event['eid']}, {
         "$pull": {"participants": {"id": member["id"]}}})
 
-    if event['maxParticipants']:
-        if len(event['participants']) >= event['maxParticipants']:
-            return {'max': True}
+    if res == None:
+        raise HTTPException(500, "Unexpected error updating database in leave")
 
-    return {'max': False}
+    return Response(status_code=200)
 
 
 @router.get('/{id}/joined', dependencies=[Depends(validate_uuid)])

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import os
 import shutil
 from fastapi import APIRouter, Response, Request, HTTPException, Depends
@@ -65,7 +65,9 @@ def get_upcoming_events(request: Request, token: AccessTokenPayload = Depends(op
     Provides public upcoming events to regular members and return all events to admin
     '''
     db = get_database(request)
-    now = datetime.now()
+    # allows ongoing events to still be visible for users
+    now = datetime.now() + timedelta(hours=4)
+
     try:
         date_str = now.strftime("%Y-%m-%d %H:%M:%S")
         date = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")

--- a/app/models.py
+++ b/app/models.py
@@ -191,11 +191,11 @@ class JobItemPayload(BaseModel):
     tags: List[str]
     description_preview: str
     description: str
-    start_date: datetime
     published_date: datetime
     location: str
     link: str
-    due_date: datetime
+    start_date: Optional[datetime]
+    due_date: Optional[datetime]
 
 
 class JobItem(JobItemPayload):

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -230,9 +230,6 @@ def test_join_event(client):
         f'/api/event/{new_event_eid}/join', json=joinEventPayload, headers=admin_header)
     assert response.status_code == 200
 
-    res = response.json()
-
-    assert res['max'] == False
     # checks response on full event
     access_token = client_login(client, payload["email"], payload["password"])
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -240,8 +237,6 @@ def test_join_event(client):
     response = client.post(
         f'/api/event/{new_event_eid}/join', json=joinEventPayload, headers=headers)
     assert response.status_code == 200
-    res = response.json()
-    assert res['max'] == True
 
     # === Test joing non public/unopened event ===
     event["public"] = False


### PR DESCRIPTION
## Allow `due_date` and `start_date` to be optional in Job announcements
  - allows for jobs listing to have "fortløpende" as deadline 
### Remove `max` indication from join/leave
  - Resolves td-org-uit-no/tdctl-frontend#140 