### PR TITLE
Feature/event reorder participants

### DIFF
--- a/.docker/docker-compose.development.yml
+++ b/.docker/docker-compose.development.yml
@@ -36,5 +36,7 @@ services:
 
 networks:
   backend:
+    # ensures pytest_docker is always on the same network
+    name: docker_backend
     external: false
     driver: bridge

--- a/.docker/docker-compose.development.yml
+++ b/.docker/docker-compose.development.yml
@@ -2,11 +2,9 @@ version: "3.5"
 services:
   tdctl_api:
     image: tdctl_api:latest
-    restart: always
     container_name: tdctl_api
-    build: ../
     volumes:
-        - ../:/app
+      - ../:/app
     build:
       context: ../
       dockerfile: .docker/dockerfile.api.development
@@ -28,7 +26,9 @@ services:
     hostname: td_mongodb
     image: mongo:latest
     command: mongod --port 26900
-    restart: always
+    restart: unless-stopped
+    ports:
+      - "26900:26900"
     volumes:
       - ../db/db_data:/data/db
     networks:

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -1,10 +1,12 @@
 from fastapi import HTTPException
 from uuid import UUID
 
+from app.models import EventDB
+
 def get_event_or_404(db, eid: str):
     event = db.events.find_one({'eid': UUID(eid)})
 
     if not event:
         raise HTTPException(404, "Event could not be found")
 
-    return event
+    return EventDB.parse_obj(event).dict()

--- a/app/assets/mails/event_confirmation.txt
+++ b/app/assets/mails/event_confirmation.txt
@@ -1,0 +1,14 @@
+Hei,
+
+Du har fått plass på $EVENT_NAME$.
+
+Dato: $DATE$
+Tidspunkt: $TIME$
+Lokasjon: $LOCATION$
+
+Skjer det endringer på arrangementet så vil dette bli gitt beskjed om. Se også: https://td-uit.no/ for mere info om arrangementet og kommende arrangementer.
+
+Hvis du ikke kan delta vennligst gi beskjed snarest, vi ønsker beskjed senest 24t før arrangementet starter. Det blir også registrert oppmøte. Hvis du ikke møter opp eller melder deg av for seint registreres dette og gjentatte hendelser vil gi nedsatt prioritet på framtidige påmeldinger.
+
+Mvh
+Tromsøstudentenes Dataforening

--- a/app/auth_helpers.py
+++ b/app/auth_helpers.py
@@ -8,7 +8,7 @@ from google.oauth2 import service_account
 
 
 from .config import Config
-from .models import MemberDB, RefreshTokenPayload, AccessTokenPayload
+from .models import MemberDB, RefreshTokenPayload, AccessTokenPayload, Role
 
 security_scheme = HTTPBearer()
 optional_security = HTTPBearer(auto_error=False)
@@ -29,7 +29,7 @@ def get_google_credentials(impersonate_email: str):
 def authorize_admin(request: Request, token: HTTPAuthorizationCredentials = Depends(security_scheme)):
     payload = authorize(request, token)
     
-    if payload.role != "admin":
+    if payload.role != Role.admin:
         raise HTTPException(403, 'Insufficient privileges to access this resource')
     return payload
 
@@ -56,7 +56,7 @@ def optional_authentication(request: Request, token: HTTPAuthorizationCredential
         return authorize(request, token)
     return None
 
-def role_required(accessToken: AccessTokenPayload, role: str):
+def role_required(accessToken: AccessTokenPayload, role: Role):
     if accessToken.role != role:
         raise HTTPException(403, 'No privileges to access this resource')
 

--- a/app/models.py
+++ b/app/models.py
@@ -220,6 +220,18 @@ class JobItemPayload(BaseModel):
     start_date: Optional[datetime]
     due_date: Optional[datetime]
 
+class UpdateJob(BaseModel):
+    company: Optional[str]
+    title: Optional[str]
+    type: Optional[str]
+    tags: Optional[List[str]]
+    description_preview: Optional[str]
+    description: Optional[str]
+    published_date: Optional[datetime]
+    location: Optional[str]
+    link: Optional[str]
+    start_date: Optional[datetime]
+    due_date: Optional[datetime]
 
 class JobItem(JobItemPayload):
     id: UUID4

--- a/app/models.py
+++ b/app/models.py
@@ -32,7 +32,6 @@ class MailPayload(BaseModel):
     to: List[EmailStr]
     sent_by: str = "no-reply@td-uit.no"
 
-
 class AccessTokenPayload(BaseModel):
     exp: int
     iat: int
@@ -117,12 +116,18 @@ class Participant(BaseModel):
     email: EmailStr
     classof: str
     phone: Optional[str]
-    role: str
+    role: Role
     food: bool
     transportation: bool
     dietaryRestrictions: str
     submitDate: datetime
     penalty: int
+    # indicate if participant has recieved an confirmation mail
+    confirmed: Optional[bool]
+
+
+class ParticipantPosUpdate(BaseModel):
+    updateList: List[create_model('ParticipantPosUpdate', id=(UUID4, ...), pos=(int, ...))]
 
 
 class EventInput(BaseModel):
@@ -145,9 +150,12 @@ class EventInput(BaseModel):
     picturePath: Optional[str]
     # time before event starting
     registrationOpeningDate: Optional[datetime]
+    confirmed: Optional[bool]
+
 
 class EventUserView(EventInput):
     eid: UUID4
+
 
 class Event(EventUserView):
     # The TD member responsible for the event
@@ -167,10 +175,12 @@ class EventUpdate(BaseModel):
     transportation: Optional[bool]
     food: Optional[bool]
     registrationOpeningDate: Optional[datetime]
+    confirmed: Optional[bool]
 
 
 class EventDB(Event):
     participants: List[Participant]
+
 
 class Tokens(BaseModel):
     accessToken: str

--- a/app/utils/event_utils.py
+++ b/app/utils/event_utils.py
@@ -14,7 +14,6 @@ def validate_registartion_opening_time(event_date, opening_date):
     return opening_date
 
 def validate_event_dates(event):
-    print(event.date, event.registrationOpeningDate)
     try:
         event_date = datetime.strptime(str(event.date), "%Y-%m-%d %H:%M:%S")
     except ValueError:
@@ -34,8 +33,6 @@ def validate_cancellation_time(start_date):
         date_str = now.strftime("%Y-%m-%d %H:%M:%S")
         date = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
         diff = abs(start_date-date)
-        print(diff)
-        print(diff>=timedelta(hours=cancellation_threshold))
     except ValueError:
         return False
     return diff>=timedelta(hours=cancellation_threshold)
@@ -65,5 +62,37 @@ def valid_registration(opening_date):
         # validates format
         registration_start = datetime.strptime(str(opening_date), "%Y-%m-%d %H:%M:%S")
     except ValueError:
-        return False
+        # sets registration open if field is malformed
+        return True
     return datetime.now()>registration_start
+
+# validates position reorder input
+#   - id:
+#     - all participants in reorder list is already joined the event
+#   - pos
+#     - validates that all pos arguments are valid i.e between 0 and len(participants)
+def validate_pos_update(participants, updateList):
+    valid_args = list(range(0, len(participants)))
+    joined_ids = [ p["id"] for p in participants ]
+    for p in updateList:
+        try:
+            valid_args.remove(p.pos)
+            joined_ids.remove(p.id)
+        except ValueError:
+            return False
+    return len(valid_args) == 0 and len(joined_ids) == 0
+
+def event_has_started(event):
+    try :
+        start_date = datetime.strptime(str(event["date"]), "%Y-%m-%d %H:%M:%S")
+        current_time = datetime.now() 
+        return current_time > start_date
+    except ValueError:
+        return True
+
+def num_of_deprioritized_participants(participants):
+    return sum(p["penalty"] > 1 for p in participants)
+
+def num_of_confirmed_participants(participants):
+    return sum(p["confirmed"] == True for p in participants)
+

--- a/db/seeds/members.json
+++ b/db/seeds/members.json
@@ -6,20 +6,20 @@
     "classof": "1984",
     "graduated": false,
     "phone": "",
-    "status": "INACTIVE",
+    "status": "inactive",
     "role": "admin",
     "penalty": 0
   },
   {
     "realName": "First Lastname",
     "email": "mail@mail.com",
-    "password": "pbkdf2:sha256:260000$vpuGwDvLJ5NRVb2S$da9eba7f81f5138e3fa1cdf855d41ce3971f55162208948cc1bc8b9d8d3495d7",
+    "password": "pbkdf2:sha256:260000$EYUpKygcwxH7gb08$bb57edda2cb281831107b1ef5449db04e7881ef3f7c796c8c6cd651888677e9c",
     "classof": "2015",
     "graduated": false,
     "phone": "",
-    "status": "INACTIVE",
+    "status": "inactive",
     "role": "member",
-    "penalty": 0
+    "penalty": 2
 
   },
   {
@@ -29,7 +29,7 @@
     "classof": "2018",
     "graduated": false,
     "phone": "12345678",
-    "status": "ACTIVE",
+    "status": "active",
     "role": "admin",
     "penalty": 0
   },
@@ -40,7 +40,7 @@
     "classof": "2015",
     "graduated": false,
     "phone": "87654321",
-    "status": "ACTIVE",
+    "status": "active",
     "role": "admin",
     "penalty": 0
   }

--- a/db/seeds/test_seeds/test_members.json
+++ b/db/seeds/test_seeds/test_members.json
@@ -6,7 +6,7 @@
     "classof": "2015",
     "graduated": false,
     "phone": "",
-    "status": "INACTIVE",
+    "status": "inactive",
     "role": "member",
     "penalty": 0
   },
@@ -17,9 +17,9 @@
     "classof": "2018",
     "graduated": false,
     "phone": "",
-    "status": "INACTIVE",
+    "status": "inactive",
     "role": "member",
-    "penalty": 0
+    "penalty": 2
   },
   {
       "realName": "Admin Adminsen",
@@ -28,7 +28,7 @@
       "classof": "2018",
       "graduated": false,
       "phone": "12345678",
-      "status": "ACTIVE",
+      "status": "active",
       "role": "admin",
       "penalty": 0
   },
@@ -39,7 +39,7 @@
       "classof": "2018",
       "graduated": false,
       "phone": "87654321",
-      "status": "ACTIVE",
+      "status": "active",
       "role": "admin",
       "penalty": 0
   }

--- a/pytest_docker.py
+++ b/pytest_docker.py
@@ -34,8 +34,6 @@ def run_mongodb_container(client, container_name):
         remove=True
     )
 # function to start up a container for running test
-
-
 def start_mongodb_container(client):
     # handle error types
     responses = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def client(app):
     test_seed_path = "db/seeds/test_seeds"
 
     with TestClient(app) as client:
+        # important that test_members.json always has a penalized member
         seed_members(app.db, f"{test_seed_path}/test_members.json")
         seed_events(app.db, f"{test_seed_path}/test_events.json")
         yield client

--- a/tests/test_endpoints/test_auth.py
+++ b/tests/test_endpoints/test_auth.py
@@ -1,8 +1,12 @@
+from app.db import get_test_db
+from app.models import Status
 from tests.conftest import client_login
 from tests.utils.authentication import authentication_required
 from app.auth_helpers import decode_token
 from app.config import config
 from tests.users import regular_member
+
+db = get_test_db()
 
 def test_login(client):
     unregister_user = {
@@ -13,6 +17,8 @@ def test_login(client):
     assert response.status_code == 401
     response = client.post("/api/auth/login", json=regular_member)
     assert response.status_code == 200
+    member = db.members.find_one({'email': regular_member["email"]})
+    assert member and member["status"] == Status.active
     res_json = response.json()
     token_payload = decode_token(res_json["accessToken"], config["test"])
     assert token_payload["access_token"] == True


### PR DESCRIPTION
# :sparkles: Add support for reordering and sending out confirmation through the API
## Structural changes
- ### :lock: Introduces a global lock allowing reordering and confirmation to ensure exclusive access to the current state of the event
  - This lock blocks all other API calls which is a sub-optimal solution and not scalable. After some research, it looks like our solution is already sequential [link](https://fastapi.tiangolo.com/async/). Which could make the lock redundant however I decided to keep the lock to be explicit and to make it work with added workers. 
- ### :twisted_rightwards_arrows: Participants ordering
  - The participants ordering is now 1-1 with the ordering of the participant's array i.e pos 0 in the participant's array is first
- ### :passport_control: join puts penalized users at the bottom, making the prioritization automatic
## :sparkles: Re-ordering participants
  - Takes in the new order and reshuffles the participant's list
  - expect full list, does not support partial update
  - Needs lock as the old list is retrieved, reshuffled, and inserted back overwriting the existing list. This allows a un-update list to be inserted back into the database
  
## :sparkles: Confirmation
  - only active on events with `bindingRegistration`
  - automatically detects if which participants should receive mail, allowing confirmation to be sent out multiple times 
  
#### Resolves:
 - Resolves td-org-uit-no/tdctl-frontend#151
 - Resolves td-org-uit-no/tdctl-frontend#134