### PR TITLE
:bug: add expiration to cookie to persist across browser close

### DIFF
--- a/app/auth_helpers.py
+++ b/app/auth_helpers.py
@@ -76,9 +76,13 @@ def role_required(accessToken: AccessTokenPayload, role: Role):
         raise HTTPException(403, 'No privileges to access this resource')
 
 def set_auth_cookies(response: Response, access_token: str, refresh_token: str):
+    # Set cookie to expire in one year. Note that the token may still be invalid
+    # even if the cookie is not expired, so this doesn't mean that the token
+    # can't be revoked
+    expiration = 31536000
     secure = os.environ.get("API_ENV") == "production"
-    response.set_cookie('access_token', access_token, httponly = True, path = "/", secure=secure)
-    response.set_cookie('refresh_token', refresh_token, httponly = True, path = "/", secure=secure)
+    response.set_cookie('access_token', access_token, httponly = True, path = "/", secure=secure, expires=expiration)
+    response.set_cookie('refresh_token', refresh_token, httponly = True, path = "/", secure=secure, expires=expiration)
 
 def delete_auth_cookies(response: Response):
     response.delete_cookie('access_token')


### PR DESCRIPTION
## Problem:
Currently, the cookie is cleared immediately when the browser is closed. This is not optimal as the user still needs to continue to login quite often

## Solution:
Add expiration date to the cookie. This will persist the cookie across browser close, and not remove it. Note that this is a different expiration than the token, and the token may still be expired even if the cookie is not. This is wanted as the cookie will then be refreshed.

I am open to a different expiration time than one year as I set it currently

## Context:
https://stackoverflow.com/questions/8204224/why-my-cookie-is-lost-when-the-browser-is-closed-expires-set-by-javascript