### PR TITLE
Feature/My events page

### DIFF
--- a/.docker/docker-compose.development.yml
+++ b/.docker/docker-compose.development.yml
@@ -13,6 +13,7 @@ services:
       DB_PORT: 26900
       TEST_DB_HOSTNAME: test_mongodb
       FRONTEND_URL: localhost:3000
+      TZ: Europe/Oslo
     links:
       - mongodb
     depends_on:

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -247,12 +247,7 @@ def get_event_options(request: Request, id: str, token: AccessTokenPayload = Dep
         "$elemMatch": {"id": UUID(token.user_id)}}})
     
     # Check whether user exists in event
-    if not user_event:
-        raise HTTPException(400, "User not joined event!")
-
-    try:
-        user_event['participants']
-    except KeyError:
+    if not user_event or 'participants' not in user_event:
         raise HTTPException(400, "User not joined event!")
 
     # Get user data and return
@@ -273,24 +268,14 @@ def update_event_options(request: Request, id: str, payload: JoinEventPayload, t
         "$elemMatch": {"id": UUID(token.user_id)}}})
     
     # Check whether user exists in event
-    if not user_event:
-        raise HTTPException(400, "User not joined event!")
-
-    try:
-        user_event['participants']
-    except KeyError:
+    if not user_event or 'participants' not in user_event:
         raise HTTPException(400, "User not joined event!")
     
     # Can validate whether payload entries are
     # actually applicable for event here
 
-    # Cannot update options for confirmed event
-    try:
-        event['confirmed']
-    except KeyError:
-        raise HTTPException(400, "Cannot update options for confirmed event")
-
-    if event['confirmed']:
+    # Cannot update options for confirmed event   
+    if event.get('confirmed'):
         raise HTTPException(400, "Cannot update options for confirmed event")
 
     # Create a dictionary with the payload
@@ -302,7 +287,7 @@ def update_event_options(request: Request, id: str, payload: JoinEventPayload, t
 
     # Return error if user was not in event
     if not res:
-        raise HTTPException(400, "User not joined event!")
+        raise HTTPException(500, "Could not find user in event")
     
 
 
@@ -440,22 +425,12 @@ def is_confirmed(request: Request, id: str, token: AccessTokenPayload = Depends(
         '$elemMatch': {'id': UUID(token.user_id)}}})
     
     # Check whether user exists in event
-    if not user_event:
-        raise HTTPException(400, "User not joined event!")
-
-    try:
-        user_event['participants']
-    except KeyError:
+    if not user_event or 'participants' not in user_event:
         raise HTTPException(400, "User not joined event!")
     
     userData = user_event['participants'][0]
     # Check whether event has been confirmed
-    try:
-        event['confirmed']
-    except KeyError:
-        raise HTTPException(400, 'Event does not have confirmation')
-    
-    if event['confirmed'] == False:
+    if not event.get('confirmed'):
         raise HTTPException(400, 'Event has not been confirmed yet')
     
     # Return user data

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -362,12 +362,10 @@ def test_join_unpublished_event(client):
 
 @authentication_required("/api/event/{uuid}/join", "post")
 def test_join_published_event(client):
-    # make copy so other test doesn't get affected
-    event = new_event.copy()
     client_login(client, admin_member["email"], admin_member["password"])
 
     # creates event with maxParticipants = 1
-    response = client.post("/api/event/", json=event)
+    response = client.post("/api/event/", json=new_event)
     new_event_eid = response.json()["eid"]
     assert response.status_code == 200
 

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -525,6 +525,39 @@ def test_is_joined_event(client):
     assert res["joined"] == True
 
 
+@authentication_required("/api/event/{uuid}/joined", "get")
+def test_is_confirmed(client):
+    # Login
+    access_token = client_login(
+        client, admin_member["email"], admin_member["password"])
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    # Create new event to confirm
+    response = client.post("/api/event/", json=new_event, headers=headers)
+    eid = response.json()["eid"]
+    assert response.status_code == 200
+
+    # Should not be confirmed
+    response = client.get(f'/api/event/{eid}/confirmed')
+    assert response.status_code == 400
+
+    # Join
+    response = client.post(f'/api/event/{eid}/join', json=joinEventPayload, headers=headers)
+    assert response.status_code == 200
+
+    # Should not be confirmed
+    response = client.get(f'/api/event/{eid}/confirmed')
+    assert response.status_code == 400
+
+    # Set event to confirmed
+    response = client.post(f'/api/event/{eid}/confirm')
+    assert response.status_code == 200
+
+    # Should be confirmed
+    response = client.get(f'/api/event/{eid}/confirmed')
+    assert response.status_code == 200
+
+
 @admin_required("/api/event/{uuid}/removeParticipant/{uuid}", "delete")
 def test_remove_participant(client):
     eid = test_events[0]["eid"]

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -250,17 +250,15 @@ def test_get_event_participants(client):
 @authentication_required("/api/event/{uuid}/options", "get")
 def test_get_event_options(client):
     # Login
-    access_token = client_login(
-        client, admin_member["email"], admin_member["password"])
-    headers = {"Authorization": f"Bearer {access_token}"}
+    client_login(client, admin_member["email"], admin_member["password"])
 
     # Add event to insert options
-    response = client.post("/api/event/", json=new_event, headers=headers)
+    response = client.post("/api/event/", json=new_event)
     eid = response.json()["eid"]
     assert response.status_code == 200
 
     # Join with options
-    response = client.post(f'/api/event/{eid}/join', json=joinEventPayload, headers=headers)
+    response = client.post(f'/api/event/{eid}/join', json=joinEventPayload)
     assert response.status_code == 200
 
     # Fetch event options
@@ -274,17 +272,15 @@ def test_get_event_options(client):
 @authentication_required("/api/event/{uuid}/options", "get")
 def test_update_event_options(client):
     # Login
-    access_token = client_login(
-        client, admin_member["email"], admin_member["password"])
-    headers = {"Authorization": f"Bearer {access_token}"}
+    client_login(client, admin_member["email"], admin_member["password"])
 
     # Create event to insert options
-    response = client.post("/api/event/", json=new_event, headers=headers)
+    response = client.post("/api/event/", json=new_event)
     eid = response.json()["eid"]
     assert response.status_code == 200
 
     # Join with options
-    response = client.post(f'/api/event/{eid}/join', json=joinEventPayload, headers=headers)
+    response = client.post(f'/api/event/{eid}/join', json=joinEventPayload)
     assert response.status_code == 200
 
     # Update options
@@ -526,12 +522,10 @@ def test_is_joined_event(client):
 @authentication_required("/api/event/{uuid}/joined", "get")
 def test_is_confirmed(client):
     # Login
-    access_token = client_login(
-        client, admin_member["email"], admin_member["password"])
-    headers = {"Authorization": f"Bearer {access_token}"}
+    client_login(client, admin_member["email"], admin_member["password"])
 
     # Create new event to confirm
-    response = client.post("/api/event/", json=new_event, headers=headers)
+    response = client.post("/api/event/", json=new_event)
     eid = response.json()["eid"]
     assert response.status_code == 200
 
@@ -540,7 +534,7 @@ def test_is_confirmed(client):
     assert response.status_code == 400
 
     # Join
-    response = client.post(f'/api/event/{eid}/join', json=joinEventPayload, headers=headers)
+    response = client.post(f'/api/event/{eid}/join', json=joinEventPayload)
     assert response.status_code == 200
 
     # Should not be confirmed

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -122,6 +122,34 @@ def test_get_upcoming_events(client):
     assert len(response.json()) == 1
 
 
+@authentication_required("/api/event/joined-events", "get")
+def test_get_joined_events(client):
+    # Login
+    client_login(client, admin_member["email"], admin_member["password"])
+
+    # Seeded events are past, should return none
+    response = client.get("/api/event/joined-events/")
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+    # Make copy to avoid affecting other tests
+    event = new_event.copy()
+    event["public"] = False
+
+    # Create upcoming, unpublished event
+    response = client.post("/api/event/", json=new_event)
+    assert response.status_code == 200
+    test_event_id = response.json()["eid"]
+
+    # Join
+    response = client.post(f'/api/event/{test_event_id}/join', json=joinEventPayload)
+    assert response.status_code == 200
+
+    # Now returns one event
+    response = client.get("/api/joined-events/")
+    assert len(response.json()) == 1
+
+
 def test_get_event_picture(client):
     eid = test_events[0]["eid"]
 


### PR DESCRIPTION
# :gem: My Events page

## :sparkles: Added four endpoints to support my events page:
- `/joined-events/` Returns all upcoming events user has joined. Admin also gets unpublished events they have joined.
- `/{id}/options/` Returns options user has registered when joining event (transport, food, allergies).
- `/{id}/update-options/` Updates user options for event with new options provided in payload.
- `/{id}/confirmed` Returns whether user is confirmed for event.

## :adhesive_bandage: Minor changes:
- :whale: Added timezone to development container to correctly display time.
- :adhesive_bandage: Removed an unnecessary event copy in join event test
