### PR TITLE
Feature/docker utils

### DIFF
--- a/.docker/docker-compose.development.yml
+++ b/.docker/docker-compose.development.yml
@@ -1,4 +1,5 @@
 version: "3.5"
+name: backend
 services:
   tdctl_api:
     image: tdctl_api:latest
@@ -25,6 +26,7 @@ services:
 
   mongodb:
     hostname: td_mongodb
+    container_name: mongodb_dev
     image: mongo:latest
     command: mongod --port 26900
     restart: unless-stopped

--- a/dev_utils.sh
+++ b/dev_utils.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+docker_command=""
+path=".docker/docker-compose.development.yml"
+utils_path=utils
+
+check_compose_version() {
+    compose_command="docker compose"
+    if ! command -v ${compose_command} &> /dev/null; then
+        # can't find docker compose, tries older version
+        compose_command="docker-compose"
+        if ! command -v $compose_command &> /dev/null; then
+            # couldn't find docker-compose i.e no version of docker compose is installed
+            return
+        fi
+    fi
+    docker_command="$compose_command -f"
+}
+
+usage() {
+    echo "Utils script for docker commands in development: 
+Required:
+    compose:
+        passes the command line arguments to '${docker_command} ${path} {provided arguments}'.
+$(exec_usage)
+    seed:
+        seeds database using the seeding file
+    test:
+        runs the docker test file, and sends any additional arguments to the pytest command
+            - 'seed -s' will be the same as 'pytest -s'
+"
+}
+
+exec_usage() {
+    echo "    exec:
+        interactive shell for development containers (api or db)
+        Options:
+            api - interactive shell for api container (default)
+            db - interactive monogsh shell for db 
+"
+}
+
+run_compose() {
+    $docker_command $path $@
+}
+
+exec_api() {
+    docker exec -it tdctl_api bash
+}
+
+exec_db() {
+    container=mongodb_dev
+    host=td_mongodb
+    port=26900
+    docker exec -it $container mongosh --host $host --port $port
+}
+
+interactive_shell() {
+    if [ $# = 0 ];then
+        # tdctl api is default exec container
+        exec_api
+        exit 1
+    fi
+    case $1 in 
+        api) shift; exec_api;;
+        db) shift; exec_db;;
+        -h | --help) shift; exec_usage;;
+        * ) exec_usage;;
+    esac
+}
+
+seed_db() {
+    # runs seeding as module (fixes imports)
+    docker exec tdctl_api python3 -m $utils_path.seeding
+}
+
+run_tests() {
+    test_file=pytest_docker.py
+    python3 $utils_path/$test_file $@
+}
+
+parse_arguments() {
+    if [ $# = 0 ];then
+        usage
+        exit 1
+    fi
+    # couldn't find docker compose or docker-compose
+    if [ -z "$docker_command" ];then
+        echo "Could not find any versions of (docker compose or docker-compose)"
+        exit 1
+    fi
+
+    case $1 in 
+        compose) shift; run_compose $@;;
+        exec) shift; interactive_shell $@;;
+        seed) shift; seed_db;;
+        test) shift; run_tests $@;;
+        -h | --help) shift; usage;;
+        * ) usage;;
+    esac
+}
+
+check_compose_version
+parse_arguments $@

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 from app import config
 from pymongo import MongoClient
 from fastapi.testclient import TestClient
-from seeding import seed_events, seed_members
+from utils.seeding import seed_events, seed_members
 
 import sys
 import os

--- a/utils/pytest_docker.py
+++ b/utils/pytest_docker.py
@@ -71,7 +71,6 @@ def setup_test_env(args):
     api_container = check_api_running(client)
     mongodb_container = start_mongodb_container(client)
     # run pytest without description warnings
-    # print(f'pytest {" ".join(args)}')
     _, stream = api_container.exec_run(f'pytest {" ".join(args)}', stream=True)
     for data in stream:
         print(data.decode(), end='')

--- a/utils/seeding.py
+++ b/utils/seeding.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from uuid import UUID, uuid4
+from uuid import uuid4
 from pymongo import MongoClient
 from werkzeug.security import generate_password_hash
 from app import config


### PR DESCRIPTION
## :man_technologist: Utils script for development (dev_utils)
**Makes development easier and make  **
  - #### Flags:
    - **compose**:
      - adds all user-provided arguments to `docker compose -f .docker/docker-comose.develoment.yml {args}` 
    - **exec**:
      - Flags:
        - api (joins api)
        - db (joins db with mongosh)
      - **Joins either API or db container, if a target is not provided, it will join the api**
     - **test**:
        - runs the `pytest_docker` script and it passes any arguments to the script
     - **seed**:
       - seeds the database via the seeding script 
 ### Moves the scripts to `utils` folder
 Since the dev_utils script uses the `seeding` and `pytest_docker` scripts it can be moved to a separate folder. Since it is no longer necessary for users to use the scripts directly