### PR TITLE
Feature/register event attendees

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,8 @@ pytest = "7.2.0"
 google-api-python-client = "2.66.0" 
 google-auth-httplib2 = "0.1.0"
 google-auth-oauthlib = "0.7.1"
+qrcode = "7.4.2"
+fpdf2 = "2.6.1"
 # python sdk for docker
 docker="6.0.1"
 pandas = "1.5.2"

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -18,6 +18,8 @@ import pandas as pd
 from .mail import send_mail
 from ..models import MailPayload
 import asyncio
+import qrcode as qr
+from fpdf import FPDF
 
 
 router = APIRouter()

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -1,7 +1,14 @@
 from fastapi import HTTPException
 from uuid import UUID
+from datetime import datetime
+
+from pymongo import UpdateOne
 
 from app.models import EventDB
+
+import asyncio
+
+lock = asyncio.Lock()
 
 def get_event_or_404(db, eid: str):
     event = db.events.find_one({'eid': UUID(eid)})
@@ -10,3 +17,81 @@ def get_event_or_404(db, eid: str):
         raise HTTPException(404, "Event could not be found")
 
     return EventDB.parse_obj(event).dict()
+
+
+async def penalize(db, uid: UUID):
+    """ Apply penalty to member. Applies to member db and all joined event participant lists """
+
+    async with lock:
+        member = db.members.find_one({'id': uid})
+
+        if not member:
+            raise HTTPException(404, "Member not found")
+        
+        
+        should_deprioritize = bool(member['penalty'] >= 1)
+
+        # Apply penalty to member db
+        res = db.members.update_one({"id": uid}, {"$inc": {"penalty": 1}})
+
+        if not res:
+            raise HTTPException(500)
+        
+        # Apply penalty to all joined events
+        now = datetime.now()
+
+        date_str = now.strftime("%Y-%m-%d %H:%M:%S")
+        date = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+
+        pipeline = [
+            {"$match": {"date": {"$gt": date}}},
+            {"$unwind": "$participants"},
+            {"$match": {"participants.id": {"$eq": uid}}}
+        ]
+        joined = db.events.aggregate(pipeline)
+
+
+        if not joined:
+            raise HTTPException(500)
+        
+        updates = []
+        updated = False
+        for event in joined:
+            # Update penalty on event
+            res = db.events.update_one({"eid": event["eid"], "participants.id": uid}, {
+                "$inc": {"participants.$.penalty": 1}
+            })
+
+
+            if not res:
+                raise HTTPException(500)
+
+            # Deprioritize for this event
+            if should_deprioritize and not event["confirmed"]:
+                # Pull member from event
+                updates.append(UpdateOne({"eid": event["eid"]}, {
+                    "$pull": {"participants": {"id": uid}}
+                }))
+                
+                participant = event["participants"]
+
+                # Add penalty
+                if not updated:
+                    participant["penalty"] += 1
+                    updated = True
+
+                if not participant:
+                    raise HTTPException(500)
+                
+                updates.append(UpdateOne({"eid": event["eid"]}, {
+                    "$push": {"participants": participant}
+                }))
+
+
+        if len(updates) == 0:
+            return
+
+        res = db.events.bulk_write(updates)
+
+        if not res:
+            raise HTTPException(500)

--- a/app/db.py
+++ b/app/db.py
@@ -15,6 +15,9 @@ def get_image_path(request: Request) -> str:
 def get_JobImage_path(request: Request) -> str:
     return request.app.jobImage_path
 
+def get_qr_path(request: Request) -> str:
+    return request.app.qr_path
+
 
 def get_export_path(request: Request) -> str:
     return request.app.export_path
@@ -27,6 +30,7 @@ def setup_db(app):
 
     # Expire reset password codes after 10 minutes
     app.db.passwordResets.create_index("createdAt", expireAfterSeconds=60 * 10)
+    app.qr_path = 'db/qr'
     if app.config.MONGO_DBNAME == 'test':
         app.image_path = 'db/testEventImages'
         return

--- a/app/models.py
+++ b/app/models.py
@@ -62,6 +62,7 @@ class AdminMemberUpdate(BaseModel):
     email: Optional[EmailStr]
     classof: Optional[str]
     phone: Optional[str]
+    penalty: Optional[int]
 
 
 class MemberUpdate(BaseModel):
@@ -108,6 +109,7 @@ class Member(BaseModel):
     phone: Optional[str]
     role: Role
     status: Status
+    penalty: int
 
 
 class Participant(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -124,6 +124,7 @@ class Participant(BaseModel):
     penalty: int
     # indicate if participant has recieved an confirmation mail
     confirmed: Optional[bool]
+    attended: Optional[bool]
 
 
 class ParticipantPosUpdate(BaseModel):
@@ -162,6 +163,8 @@ class Event(EventUserView):
     host: EmailStr
     # Collects all user penalties registered, ensuring only one penalty is given per event
     registeredPenalties: List[UUID4]
+    # Register id
+    register_id: Optional[UUID4]
 
 
 class EventUpdate(BaseModel):
@@ -215,6 +218,11 @@ class JoinEventPayload(BaseModel):
 class PenaltyInput(BaseModel):
     penalty: int = Field(
         ge=0, description="Penalty must be larger or equal to 0")
+    
+
+class SetAttendancePayload(BaseModel):
+    member_id: Optional[str]
+    attendance: bool
 
 
 class JobItemPayload(BaseModel):

--- a/app/utils/event_utils.py
+++ b/app/utils/event_utils.py
@@ -89,6 +89,19 @@ def event_has_started(event):
         return current_time > start_date
     except ValueError:
         return True
+    
+def event_starts_in(event, dt):
+    """ 
+    Return whether event has started, calculated with the given
+    time delta (in hours)
+    """
+    try:
+        start_date = datetime.strptime(str(event['date']), "%Y-%m-%d %H:%M:%S")
+        current_time = datetime.now() + timedelta(hours=dt)
+        return current_time > start_date
+    except ValueError:
+        return True
+
 
 def num_of_deprioritized_participants(participants):
     return sum(p["penalty"] > 1 for p in participants)

--- a/db/qr/.gitignore
+++ b/db/qr/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_endpoints/test_event.py
+++ b/tests/test_endpoints/test_event.py
@@ -122,6 +122,20 @@ def test_get_upcoming_events(client):
     assert len(response.json()) == 1
 
 
+def test_get_past_events(client):
+    # Login
+    client_login(client, admin_member["email"], admin_member["password"])
+
+    # Create future event
+    response = client.post('/api/event/', json=new_event)
+    assert response.status_code == 200
+
+    # Should only get past events
+    response = client.get('/api/event/past-events/')
+    assert response.status_code == 200
+    assert len(response.json()) == len(test_events)
+
+
 @authentication_required("/api/event/joined-events", "get")
 def test_get_joined_events(client):
     # Login

--- a/utils/seeding.py
+++ b/utils/seeding.py
@@ -96,6 +96,7 @@ def seed_events(db, seed_path):
             ) + timedelta(hours=random.choices(
                 dates, weights=date_weights, k=1)[0])
             member['confirmed'] = False
+            member['attended'] = False
             event["participants"].append(member)
 
         img_dst = "db/eventImages/"


### PR DESCRIPTION
# :gem: Register Event Attendees

## :sparkles: Attendance to binding events can now be registered. The following endpoints have been added:

- `put("/{eid}/register")` Register attendance of self or member given in payload (optional, requires admin)
- `post("/{eid}/register-absence")` Register absence on finished event, giving penalty to all unattended
- `post("/{eid}/qr")` Create a 'register id' and qr code pdf for given event, if one doesn't exist already
- `get("/{eid}/qr")` Get qr code pdf for event

Register id is created because the url to register must be confidential, only shared physically using a QR code.

 :sparkles: Endpoint has also been added to get the past 10 events. This will allow admins to find the event after it has happened to register absence. It does not require admin to access, however.

## :art: Penalizing a member has been extracted to its own function
The function currently applies the penalty to the member itself in the database, as well as the participant entries to all upcoming joined events. Should the participant reach a penalty level of 2, they will also be moved to the bottom of any joined unconfirmed events.
 
:robot: Automization of registering absence and penalizing members  a couple of days after an event has completed can be added in a future PR.

:sparkles: Penalty for each member can now also be updated by admins. This update will only affect the member in the database, and not the participant entries for any joined events.

## :camera: The QR pdf looks like this:
![image](https://user-images.githubusercontent.com/73795796/233725901-b4e18f0c-6db6-4532-8fca-cac1f31ef5e1.png)
