### PR TITLE
:bug: Fix admin member update accepting 0 as penalty

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -68,7 +68,7 @@ def update_member(request: Request, id: str, memberData: AdminMemberUpdate, toke
     values = memberData.dict()
     updateInfo = {}
     for key in values:
-        if values[key]:
+        if values[key] or values[key] == 0:
             updateInfo[key] = values[key]
 
     if not updateInfo:


### PR DESCRIPTION
Removed a check on the admin member update endpoint to also accept empty values on member update. This will allow admins to set someones penalty to 0, which was not possible before.
