### PR TITLE
:speech_balloon: Specify contact information in confirmation mail

### DIFF
--- a/app/assets/mails/event_confirmation.txt
+++ b/app/assets/mails/event_confirmation.txt
@@ -6,9 +6,11 @@ Dato: $DATE$
 Tidspunkt: $TIME$
 Lokasjon: $LOCATION$
 
-Skjer det endringer på arrangementet så vil dette bli gitt beskjed om. Se også: https://td-uit.no/ for mere info om arrangementet og kommende arrangementer.
+Skjer det endringer på arrangementet så vil dette bli gitt beskjed om. Se også: https://td-uit.no/ for mer info om arrangementet og kommende arrangementer.
 
-Hvis du ikke kan delta vennligst gi beskjed snarest, vi ønsker beskjed senest 24t før arrangementet starter. Det blir også registrert oppmøte. Hvis du ikke møter opp eller melder deg av for seint registreres dette og gjentatte hendelser vil gi nedsatt prioritet på framtidige påmeldinger.
+Hvis du ikke kan delta vennligst meld deg av via nettsiden snarest, vi ønsker beskjed senest 24t før arrangementet starter. Det blir også registrert oppmøte. Hvis du ikke møter opp eller melder deg av for seint registreres dette og gjentatte hendelser vil gi nedsatt prioritet på framtidige påmeldinger.
+
+Melder du deg av for seint grunnet sykdom eller annen gyldig grunn kan du henvende deg til bedriftskommunikasjon@td-uit.no for vurdering.
 
 Mvh
 Tromsøstudentenes Dataforening


### PR DESCRIPTION
# Specify and clarify event confirmation email
- Clarified that leaving an event must be done through the website
- Specified the email to send penalty removing requests to

Is the specified email correct? Is the text clear enough that you are not guaranteed to have your penalty removed?