### PR TITLE
Feature/store user traffic

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,5 +28,6 @@ docker="6.1.2"
 pandas = "2.1.1"
 numpy = "1.26.0"
 xlsxwriter = "3.1.7"
+pybloom-live="4.0.0"
 [requires]
 python_version = "3.11"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,8 @@
 import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+from app.api import stats
 from .config import config
 
 from .api import members, auth, events, admin, mail, jobs
@@ -27,6 +29,10 @@ def create_app():
         allow_headers=["*"],
     )
 
+    # Fetch config object
+    env = os.getenv('API_ENV', 'default')
+    app.config = config[env]
+
     # Routers
     app.include_router(members.router, prefix="/api/member", tags=['members'])
     app.include_router(auth.router, prefix="/api/auth", tags=['auth'])
@@ -34,10 +40,8 @@ def create_app():
     app.include_router(admin.router, prefix="/api/admin", tags=['admin'])
     app.include_router(mail.router, prefix="/api/mail", tags=['mail'])
     app.include_router(jobs.router, prefix="/api/jobs", tags=['job'])
-
-    # Fetch config object
-    env = os.getenv('API_ENV', 'default')
-    app.config = config[env]
+    # only visible in development
+    app.include_router(stats.router, prefix="/api/stats", tags=['stats'], include_in_schema=app.config!='production')
 
     setup_db(app)
     # Set tokens to expire at at "exp"

--- a/app/api/stats.py
+++ b/app/api/stats.py
@@ -1,0 +1,221 @@
+import math
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+from uuid import UUID
+from app.api.utils import find_object_title_from_path
+from fastapi import APIRouter, Depends, HTTPException, Request, BackgroundTasks, Response
+from app.auth_helpers import authorize, authorize_admin
+from app.db import get_database
+import pickle as pkl
+from app.utils.date import Interval, add_continous_datapoints_to_log, format_date
+from pybloom_live import ScalableBloomFilter
+
+from app.models import AccessTokenPayload, PageVisit
+
+
+router = APIRouter()
+
+# groups all timestamps to their day, but can be extended to group to an arbitrary time
+@router.get('/unique-visit')
+def get_number_of_unique_visitors(request: Request, start: Optional[str] = None, end:Optional[str] = None, token: AccessTokenPayload = Depends(authorize_admin)):
+    ''' Get unique visitors with an optional interval \n
+        start: if start date is not provided it uses the first recorded timestamp as start date \n
+        end: if end date is not provided it uses the current date
+    '''
+    db = get_database(request)
+    datetime_format = "%Y-%m-%d %H:%M:%S"
+    interval = Interval.day
+    if end == None:
+        end_date = datetime.now()
+    else :
+        end_date = format_date(end, datetime_format)
+
+    match_query = {"timestamp": {"$lte": end_date}}
+    # format on the aggregate query i.e the interval visits are grouped in 
+    query_format = "%Y-%m-%d"
+    start_date = None
+    if start:
+        start_date = format_date(start, datetime_format)
+        start_query = {"timestamp": {"$gte": start_date}}
+        # redefine match_query to contain start
+        match_query = {"$and": [start_query, match_query]}
+
+        if start_date >= end_date:
+            raise HTTPException(400, "Start date cannot be larger then end date")
+        date_range = math.ceil((end_date-start_date).total_seconds()/3600)
+        # checks for interval less than one day to group the dates in more detailed groups
+        if  date_range <= 48:
+            interval = Interval.hour
+            query_format = f"{query_format}T%H"
+
+    pipeline = [
+        {"$match": match_query},
+        {"$group": {
+            # could only use $dateToString in _id field
+            "_id": {"$dateToString": {"format": query_format, "date": "$timestamp"}},
+            "count" :  {"$sum": 1},
+        }},
+        {"$sort": {"_id": 1}},
+        {"$project": {
+            "date": "$_id",
+            "count": 1,
+            "_id": 0,
+        }}
+    ]
+
+    res = db.uniqueVisitLog.aggregate(pipeline)
+    visits = list(res)
+    if not len(visits):
+        return visits
+
+    if not start_date:
+        # if start date is not provided the first timestamp is used as start date
+        start_date = format_date(visits[0]["date"], query_format)
+    return add_continous_datapoints_to_log(visits, start_date, end_date, interval)
+
+def register_new_visit(db, user_id):
+    member = db.members.find_one({'id': UUID(user_id)})
+    if not member:
+        logging.error(f"404 - User with {user_id} could not be found")
+        return
+    today = datetime.today().strftime('%Y-%m-%d')
+    stats = db.uniqueFilter.find_one({'entry_date': today})
+    update_dict = {}
+    # checks if bloomfilter is added for the day
+    if not stats:
+        update_dict = {
+            "createdAt": datetime.utcnow(),
+            "entry_date": today,
+        }
+        # adds a fresh bloomfilter
+        bf = ScalableBloomFilter(initial_capacity=1000, error_rate=0.001, mode=ScalableBloomFilter.SMALL_SET_GROWTH)
+    else:
+        # load the existing filter into memory
+        bf = pkl.loads(stats["bloom_filter"])
+
+    # add returns True if key exists in filter and false on successful insert(for some reason)
+    exists = bf.add(user_id)
+    if exists:
+        return
+
+    # stores time object instead of string representation since we don't need to format
+    # 26 bytes per entry timestamp and _id
+    ts = datetime.now()
+    res = db.uniqueVisitLog.insert_one({"timestamp": ts})
+    if not res:
+        logging.error(f"could not insert timestamp: {ts}")
+        return
+
+    update_dict.update({"bloom_filter": pkl.dumps(bf)})
+
+    # upsert=True to create the document if non is found for this date
+    res = db.uniqueFilter.update_one({'entry_date': today}, {"$set": update_dict}, upsert=True)
+    if not res:
+        logging.error(f"could not update bloom_filter with: {today}, {update_dict}")
+
+@router.post('/unique-visit')
+async def add_unique_member_visit(request: Request, background_task: BackgroundTasks, token: AccessTokenPayload = Depends(authorize)):
+    ''' endpoint to track unique visitors per day. Uses background_tasks as we want to return 200 ok at once.
+        The reason is that this endpoint should have minimal effect on the user and errors should only be logged.
+    '''
+    db = get_database(request)
+    background_task.add_task(register_new_visit, db, token.user_id)
+    return Response(status_code=200)
+
+def register_page_visit(db, page):
+    ts = datetime.now()
+    res = db.pageVisitLog.insert_one({"timestamp": ts, "metaData": page, "visits": 1})
+    if not res:
+        logging.error(f"could not insert visit on page: {page}")
+
+# builds on top of the react-router-dom location.pathname for identifying the page
+@router.post('/page-visit')
+async def add_page_visit(request: Request, payload: PageVisit, background_task: BackgroundTasks):
+    db = get_database(request)
+    background_task.add_task(register_page_visit, db, payload.page)
+    return Response(status_code=200)
+
+# gets the numbers of visit for a page between start and end
+# if end is not specified its set to datetime.now()
+@router.get('/page-visits')
+def get_page_visits(request: Request, page: str, start: Optional[str] = None, end: Optional[str] = None, token: AccessTokenPayload = Depends(authorize_admin)):
+    db = get_database(request)
+    datetime_format = "%Y-%m-%dT%H:%M:%S"
+    search_consitions = []
+
+    if end == None:
+        end_date = datetime.now()
+    else :
+        end_date = format_date(end, datetime_format)
+
+    end_query = {"timestamp": {"$lte": end_date}}
+    search_consitions.append(end_query)
+    start_date = None
+
+    if start:
+        start_date = format_date(start, datetime_format)
+        start_query = {"timestamp": {"$gte": start_date}}
+        # redefine match_query to contain start
+        search_consitions.append(start_query)
+
+        if start_date >= end_date:
+            raise HTTPException(400, "Start date cannot be larger then end date")
+    search_consitions.append({"metaData": page})
+    pipeline = [
+        {"$match": {"$and": search_consitions}},
+        {"$group": {
+            # could only use $dateToString in _id field
+            "_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$timestamp"}},
+            "count" :  {"$sum": 1},
+        }},
+        {"$sort": {"_id": 1}},
+        {"$project": {
+            "date": "$_id",
+            "count": 1,
+            "_id": 0,
+        }}
+    ]
+
+    res = db.pageVisitLog.aggregate(pipeline)
+    visits = list(res)
+
+    if not len(visits):
+        return visits
+
+    if not start_date:
+        # if start date is not provided the first timestamp is used as start date
+        start_date = format_date(visits[0]["date"], "%Y-%m-%d")
+
+    return add_continous_datapoints_to_log(visits, start_date, end_date, Interval.day)
+
+@router.get('/most_visited_pages_last_month')
+def get_most_visited_page(request: Request, token: AccessTokenPayload = Depends(authorize_admin)):
+    db = get_database(request)
+    now = datetime.now()
+    start_date = now - timedelta(weeks=4) 
+    pipeline = [
+        {"$match": {"$and": [{"timestamp": {"$lte": now}}, {"timestamp": {"$gte": start_date}}]}},
+        {"$group": {
+            # could only use $dateToString in _id field
+            "_id": "$metaData",
+            "count" :  {"$sum": 1},
+        }},
+        {"$sort": {"count": -1}},
+        {"$limit": 5},
+        {"$project":{
+            "_id": 0,
+            "path": "$_id",
+            "count": "$count"
+        }}
+    ]
+    res = db.pageVisitLog.aggregate(pipeline)
+    pages = list(res)
+    
+    for page in pages:
+        path = page["path"]
+        title = find_object_title_from_path(path, db)
+        if not title:
+            title = path
+        page.update({"title": title})
+    return pages

--- a/app/db.py
+++ b/app/db.py
@@ -1,5 +1,5 @@
 from pymongo.database import Database
-from app import config
+from app.config import config
 from pymongo import MongoClient
 from fastapi import Request
 
@@ -22,22 +22,38 @@ def get_qr_path(request: Request) -> str:
 def get_export_path(request: Request) -> str:
     return request.app.export_path
 
+def setup_stats_collections(app):
+    vists_collection_name = "uniqueVisitLog"
+    if not vists_collection_name in app.db.list_collection_names():
+        # create timeseries collection for logging unique users
+        app.db.create_collection(vists_collection_name, timeseries={"timeField": "timestamp"})
+
+    # setup timeseries for logging page visits
+    page_vists_collection_name = "pageVisitLog"
+    if not page_vists_collection_name in app.db.list_collection_names():
+        # create timeseries collection for logging unique users
+        app.db.create_collection(page_vists_collection_name, timeseries={"timeField": "timestamp", "metaField": "metaData"})
+
+    # bloom_filter will be removed after 24 hours as its not used after the day is over
+    app.db.uniqueFilter.create_index("createdAt", expireAfterSeconds=24*60*60 )
 
 def setup_db(app):
     app.db = MongoClient(app.config.MONGO_URI, uuidRepresentation="standard")[
         app.config.MONGO_DBNAME]
     file_storage_path = "db/file_storage"
+    app.image_path = f'{file_storage_path}/event_images'
+    app.jobImage_path = f'{file_storage_path}/job_images'
     app.export_path = f'{file_storage_path}/event_exports'
 
+    # setup all collections needed for tracking user activity
+    setup_stats_collections(app)
+    
     # Expire reset password codes after 10 minutes
     app.db.passwordResets.create_index("createdAt", expireAfterSeconds=60 * 10)
     app.qr_path = f'{file_storage_path}/qr'
     if app.config.MONGO_DBNAME == 'test':
         app.image_path = 'db/test_event_images'
         return
-    app.image_path = f'{file_storage_path}/event_images'
-    app.jobImage_path = f'{file_storage_path}/job_images'
-
 
 def get_test_db():
     test_config = config['test']

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from typing import Literal, Optional, List
+from typing import Dict, Literal, Optional, List
 from pydantic import BaseModel, EmailStr, UUID4, create_model, field_validator
-from datetime import datetime
+from datetime import datetime, date
 
 from pydantic.fields import Field
 
@@ -262,3 +262,28 @@ class UpdateJob(BaseModel):
 
 class JobItem(JobItemPayload):
     id: UUID4
+
+
+class UniqueVisitsStructure(BaseModel):
+    entry_date: date
+    # bloom filter object
+    bloom_filter: bytes
+    timestamps: List[date]
+
+class PageVisitsStructure(BaseModel):
+    # tracks 
+    url_dict: Dict[str, int]
+
+class PageVisitStamp(BaseModel):
+    pass
+
+class PageVisit(BaseModel):
+    page: str
+
+class PageVisits(PageVisit):
+    start: date
+    end: date
+
+class Stats(BaseModel):
+    date: date
+

--- a/app/utils/date.py
+++ b/app/utils/date.py
@@ -1,0 +1,66 @@
+from datetime import datetime, date, timedelta
+from enum import Enum
+from fastapi import HTTPException
+import math
+
+# returns formatted date, does not validate user input 
+def format_date(input_date: str, format: str):
+    try:
+        formated = datetime.strptime(input_date, format)
+    except ValueError as e:
+        raise HTTPException(400, "Invalid date format")
+    return formated
+
+class Interval(Enum):
+    hour = 0,
+    day = 1,
+
+def add_continous_datapoints_to_log(log_dict, start:datetime, end:datetime, interval: Interval):
+    if (interval == Interval.day):
+        return add_continous_datapoints_in_days(log_dict, start, end)
+    if (interval == Interval.hour):
+        return add_continous_datapoints_in_hours(log_dict, start, end)
+    return []
+
+# fill gaps in logging result, with {"count": o, "date": missing_date} 
+# to get continuous data points
+def add_continous_datapoints_in_days(log_dict, start:datetime, end:datetime):
+    date_range = (end - start).days
+    ts_format = "%Y-%m-%d"
+    # fill dates not captured in aggregate with 0 visits
+    for i in range(0, date_range):
+        insert = True
+        search_date = start.date() + timedelta(days=i)
+        for log in log_dict:
+            visit_date = format_date(log["date"], ts_format)
+            if visit_date.date() == search_date:
+                insert = False
+                break
+        if insert:
+            new_entry = {"count": 0, "date": search_date.strftime(ts_format)}
+            log_dict.insert(i, new_entry)
+    return log_dict
+
+# same as add_continous_datapoints_in_days just for hour
+def add_continous_datapoints_in_hours(log_dict, start:datetime, end:datetime):
+    date_range = (end - start).total_seconds()
+    # convert to hours
+    date_range = math.ceil(date_range/3600)
+    ts_format: str = "%Y-%m-%dT%H"
+    start = start.replace(minute=0, second=0)
+    # fill dates not captured in aggregate with 0 visits
+    for i in range(0, date_range):
+        insert = True
+        search_date = start + timedelta(hours=i)
+        group_datatpoints(log_dict, search_date, insert,i, ts_format)
+    return log_dict
+
+def group_datatpoints(log_dict, search_date, insert, idx, ts_format):
+    for log in log_dict:
+        visit_date = format_date(log["date"], ts_format)
+        if visit_date == search_date:
+            insert = False
+            break
+    if insert:
+        new_entry = {"count": 0, "date": search_date.strftime(ts_format)}
+        log_dict.insert(idx, new_entry)

--- a/db/seeds/events.json
+++ b/db/seeds/events.json
@@ -37,7 +37,7 @@
     "eid": "b70dcae276834ca78f457e47d1036cfb",
     "title": "React workshop med Bekk",
     "address": "Realfagbygget A036",
-    "date": "2023-04-25 16:30:00",
+    "date": "2030-04-25 16:30:00",
     "duration": 2,
     "price": 0,
     "maxParticipants": 30,

--- a/tests/test_endpoints/test_stats.py
+++ b/tests/test_endpoints/test_stats.py
@@ -1,0 +1,109 @@
+import datetime
+import pytest
+from app.db import get_test_db
+from tests.conftest import client_login
+from tests.users import regular_member, admin_member
+from tests.utils.authentication import admin_required, authentication_required
+from datetime import datetime, timedelta
+
+from tests.utils.stats import add_unique_visits
+
+page_payload = {
+    'page': '/test_page/1'
+}
+datetime_format = "%Y-%m-%d %H:%M:%S"
+
+@authentication_required('/api/stats/unique-visit', 'post')
+def test_uniquie_visit(client):
+    db = get_test_db()
+    client_login(client, regular_member['email'], regular_member['password'])
+    response = client.post("/api/stats/unique-visit")
+    assert response.status_code == 200
+    log = db.uniqueVisitLog.find({})
+    assert len(list(log)) == 1
+
+    # bloom filter can give false positives however this should always work 
+    response = client.post("/api/stats/unique-visit")
+    assert response.status_code == 200
+    log = db.uniqueVisitLog.find({})
+    assert len(list(log)) == 1
+
+def test_add_page_visit(client):
+    db = get_test_db()
+    response = client.post("api/stats/page-visit", json=page_payload)
+    assert response.status_code == 200
+    res = db.pageVisitLog.find({"metaData": page_payload["page"]})
+    assert res != None
+    pages = list(res)
+    assert len(pages) == 1
+    assert pages[0]["metaData"] == page_payload['page']
+
+@admin_required('/api/stats/unique-visit/', 'get')
+def test_get_unique_visits(client):
+    db = get_test_db()
+    add_unique_visits(db)
+    client_login(client, admin_member['email'], admin_member['password'])
+    now = datetime.now()
+    url = "/api/stats/unique-visit"
+    params = {
+        "end": now.isoformat(),
+    }
+    res = client.get(url, params=params)
+    # expects 400 on wrong format
+    assert res.status_code == 400
+    yesterday = now - timedelta(days=1)
+    start = yesterday.replace(hour=10)
+    start = start.strftime(datetime_format)
+    params['start'] = start
+    # end of day
+    params['end'] = f"{yesterday.year}-{yesterday.month}-{yesterday.day} 23:59:59"
+    res = client.get(url, params=params)
+    assert res.status_code == 200
+    visits = res.json()
+    count = 0
+    for visit in visits:
+        count += visit["count"]
+    # 5 visits per day inserted in seed
+    assert count == 5
+
+@admin_required('/api/stats/page-visits', 'get')
+def test_get_page_visits(client):
+    client_login(client, admin_member['email'], admin_member['password'])
+    num_visits = 3
+    for _ in range(num_visits):
+        response = client.post("api/stats/page-visit", json=page_payload)
+        if response.status_code != 200:
+            pytest.fail(f"Problem setting up page visits, got response {response.status_code}")
+    yesterday = datetime.now() - timedelta(days=1)
+    yesterday = yesterday.strftime(datetime_format)
+    params = {
+        "page": page_payload['page'],
+    }
+    res = client.get('/api/stats/page-visits', params=params)
+    assert res.status_code == 200
+    res = res.json()
+    assert res[0]["count"] == num_visits
+
+@admin_required('/api/stats/most_visited_pages_last_month/', 'get')
+def test_most_visited_pages_last_30_days(client):
+    client_login(client, admin_member['email'], admin_member['password'])
+
+    # add 6 different pages with descending numbers of visits
+    for i in range(6):
+        for _ in range(i):
+            page_payload['page'] = f"/test_page/{i}"
+            response = client.post("api/stats/page-visit", json=page_payload)
+            if response.status_code != 200:
+                pytest.fail("Failed to setup page visits in setup")
+    res = client.get('/api/stats/most_visited_pages_last_month/')
+    assert res.status_code == 200
+    page_visits = res.json()
+    assert len(page_visits) == 5
+    # test that the endpoint retrieves the 5 most visited pages
+    for page in page_visits:
+        # gets the last part of the page name path
+        sub_paths = page["path"].split("/")
+        num = sub_paths[-1]
+        # all paths should have the same amount of visits as their num
+        assert int(num) == page["count"]
+

--- a/tests/utils/stats.py
+++ b/tests/utils/stats.py
@@ -1,0 +1,17 @@
+
+from datetime import datetime, timedelta
+
+def add_unique_visits(db):
+    db.uniqueVisitLog.delete_many({})
+    now = datetime.now()
+
+    # generates a year of 5 visits per day
+    # one per hour from 12:00
+    for i in range(0, 365):
+        new_date = now - timedelta(days=i)
+        for j in range(0, 5):
+            hour = 12 + j
+            minute = 0
+            ts = new_date.replace(hour=hour, minute=minute)
+            db.uniqueVisitLog.insert_one({"timestamp": ts})
+


### PR DESCRIPTION
## Tracking of unique visits and page visits 🕵️ 

### Unique visits
*Anonymous tracking of unique visits per day*
Uses bloom filter to check if a user has visited today. This allows users to be tracked without storing any user information meaning we don't have to have "terms and condition" in fronted.
After the day is over the bloom filter is removed from the database.
##### Mongodb timeseries
Uses time series to store the timestamp when the unique users was detected. Mongodb time series is specialised on storing these kinds of data and allow for fast queries and efficient storage.

#### Get unique visits
To allow minimal work for the frontend the endpoint gives the date with different intervals based on the range specified in the request. Meaning when the interval is under 48 hours the data is grouped to their hour when over the data is grouped to their day.

### Page visits
*Tracks visits on different pages on the website*
The api blindly accepts a path and store it in a time series collection. This allows the fronted to send post request with different page visits.
As the fronted sends the `location.pathname` many pages will have path name contains their uuid. To allow the pages to be displayed with more readable names the api has function for finding the database object based on the path. 

#### Most viewed pages last 30 days:
Endpoint for giving the 5 most viewed pages in the last 30 days

Resolves td-org-uit-no/tdctl-frontend#71

### Something to consider 💡 
#### Reddis cache 
Setup reddis cache for the 30 most viewed page
    - This cache can do the initial work of checking the most visited page at startup and then keep track in memory nd return fast results. 
#### Stats service
  - Run the stats service on a separate server as an individual service with its own database avoiding load on the main API.
 - Since the stats api uses a lot common functionalities its a jobb to move the common functionalities to another repo and requires more maintenance.  