### PR TITLE
:sparkles: increase access token duration to one hour

### DIFF
--- a/app/auth_helpers.py
+++ b/app/auth_helpers.py
@@ -92,7 +92,7 @@ def delete_auth_cookies(response: Response):
 def create_token(user: MemberDB, config: Config):
     payload = {
         # Token lifetime
-        'exp': datetime.utcnow() + timedelta(days=0, minutes=10),
+        'exp': datetime.utcnow() + timedelta(days=0, hours=1),
         'iat': datetime.utcnow(),
         'user_id': user.id.hex,
         'role': user.role,


### PR DESCRIPTION
## Increase `access_token` duration from 10 minutes to one hour ⚡ 
I don't know why I haven't changed this before but 10 minutes is a short duration for an access token. Increasing this duration should minimise the request for new tokens during a session.