### PR TITLE
:bug: fix stats docs in prod not being hidden

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -41,7 +41,7 @@ def create_app():
     app.include_router(mail.router, prefix="/api/mail", tags=['mail'])
     app.include_router(jobs.router, prefix="/api/jobs", tags=['job'])
     # only visible in development
-    app.include_router(stats.router, prefix="/api/stats", tags=['stats'], include_in_schema=app.config!='production')
+    app.include_router(stats.router, prefix="/api/stats", tags=['stats'], include_in_schema=app.config.ENV!='production')
 
     setup_db(app)
     # Set tokens to expire at at "exp"


### PR DESCRIPTION
## 🐛 stats api docs should not be public as it should only be used by the website
uses app.config.env and not app.config