### PR TITLE
✨ Add support for admin-to-admin member updates (remove 403 guard)

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -79,8 +79,8 @@ def update_member(request: Request, id: str, memberData: AdminMemberUpdate, toke
     if not member:
         raise HTTPException(404, "User not found")
 
-    if member["role"] == Role.admin:
-        raise HTTPException(403, "Admin cannot update another admin")
+    ##if member["role"] == Role.admin:
+      ##  raise HTTPException(403, "Admin cannot update another admin")
 
     result = db.members.find_one_and_update(
         {'id': member["id"]}, 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -79,8 +79,6 @@ def update_member(request: Request, id: str, memberData: AdminMemberUpdate, toke
     if not member:
         raise HTTPException(404, "User not found")
 
-    ##if member["role"] == Role.admin:
-      ##  raise HTTPException(403, "Admin cannot update another admin")
 
     result = db.members.find_one_and_update(
         {'id': member["id"]}, 

--- a/tests/test_endpoints/test_admin.py
+++ b/tests/test_endpoints/test_admin.py
@@ -72,10 +72,10 @@ def test_admin_update_member(client):
     assert admin
 
     response = client.put(f"/api/admin/member/{admin['id'].hex}", json=update_value)
-    assert response.status_code == 403
+    assert response.status_code == 201
 
     admin = db.members.find_one({'email': second_admin["email"]})
-    assert admin and update_value["classof"] != admin["classof"]
+    assert admin and update_value["classof"] == admin["classof"]
 
 @admin_required("api/admin/member/{uuid}", "delete")
 def test_delete_user(client):


### PR DESCRIPTION
This commit will:

Remove the 403 check that prevented an admin from updating another admin in app/api/admin.py (commented out the role gate).

Keep the endpoint behavior as successful update (201 Created).

Update tests/test_endpoints/test_admin.py to expect 201 and assert that the classof field is actually updated (== update_value[classof]).

Fixes td-org-uit-no/tdctl-frontend#212