### PR TITLE
✨Add waitlist-only option to event email popup API

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -10,6 +11,11 @@ from .db import setup_db
 
 
 def create_app():
+    # Configure logging to show INFO level logs
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s:\t%(name)s - %(message)s'
+    )
     app = FastAPI(
         title="TDCTL-API",
         version="0.1",

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,4 @@
 import os
-import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -11,11 +10,6 @@ from .db import setup_db
 
 
 def create_app():
-    # Configure logging to show INFO level logs
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(levelname)s:\t%(name)s - %(message)s'
-    )
     app = FastAPI(
         title="TDCTL-API",
         version="0.1",

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -615,10 +615,11 @@ async def send_notification_mail(request: Request, id: str, m: EventMailMessage,
 
     # Only send mail to confirmed participants if specified
     if m.confirmedOnly:
-        pipeline.append({"$match": {"participants.confirmed": True}})
+        pipeline += [{"$match": {"participants.confirmed": True}}]
 
+    # Only send mail to waitlisted participants if specified
     if m.waitListOnly:
-        pipeline.append({"$match": {"participants.confirmed": False}})
+        pipeline += [{"$match": {"participants.confirmed": False}}]
 
     # Group by email after filtering
     pipeline.append({"$group": {"_id": "$participants.email"}})

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -598,6 +598,9 @@ async def send_notification_mail(request: Request, id: str, m: EventMailMessage,
 
     if m.confirmedOnly and num_of_confirmed_participants(event["participants"]) == 0:
         raise HTTPException(400, "No confirmed participants in event")
+    
+    if m.waitListOnly and num_of_waitlist_participants(event["participants"]) == 0:
+        raise HTTPException(400, "No waitlist participants in event")
 
     if len(m.subject) > 50:
         raise HTTPException(400, "Email subject is too long")
@@ -608,12 +611,17 @@ async def send_notification_mail(request: Request, id: str, m: EventMailMessage,
     pipeline = [
         {"$match": {"eid": event["eid"]}},
         {"$unwind": {"path": "$participants"}},
-        {"$group": {"_id": "$participants.email"}},
     ]
 
     # Only send mail to confirmed participants if specified
     if m.confirmedOnly:
-        pipeline += [{"$match": {"participants.confirmed": True}}]
+        pipeline.append({"$match": {"participants.confirmed": True}})
+
+    if m.waitListOnly:
+        pipeline.append({"$match": {"participants.confirmed": False}})
+
+    # Group by email after filtering
+    pipeline.append({"$group": {"_id": "$participants.email"}})
 
     participantsToMail = db.events.aggregate(pipeline)
     mailingList = [p["_id"] for p in participantsToMail]

--- a/app/models.py
+++ b/app/models.py
@@ -208,6 +208,7 @@ class EventMailMessage(BaseModel):
     subject: str
     msg: str
     confirmedOnly: Optional[bool] = False
+    waitListOnly: Optional[bool] = False
 
 
 class EventDB(Event):

--- a/app/utils/event_utils.py
+++ b/app/utils/event_utils.py
@@ -127,6 +127,8 @@ def num_of_deprioritized_participants(participants):
 def num_of_confirmed_participants(participants):
     return sum(p["confirmed"] == True for p in participants)
 
+def num_of_waitlist_participants(participants):
+    return sum(p["confirmed"] == False for p in participants)
 
 def get_default_confirmation(event):
     with open("./app/assets/mails/event_confirmation.txt", 'r') as mail_content:


### PR DESCRIPTION
## Summary
Adds support for sending emails specifically to waitlisted participants.

## Changes
- Added `waitListOnly` parameter to filter non-confirmed participants
- Implemented validation to check waitlist participant count
- Extended aggregation pipeline with confirmation status filtering

## Testing
Tested by logging recipient emails and verifying correct filtering of waitlisted participants.